### PR TITLE
add option to force contextual lookup 

### DIFF
--- a/anki_configuration.lua
+++ b/anki_configuration.lua
@@ -94,6 +94,7 @@ local Configuration = {
     Setting:new{ id = 'def_field',          required = true },
     Setting:new{ id = 'dupe_scope',         default = 'deck' },
     Setting:new{ id = 'allow_dupes',        default = false },
+    Setting:new{ id = 'trust_first_dict',   default = false },
     Setting:new{ id = 'custom_tags',        default = {} },
     Setting:new{ id = 'enabled_extensions', default = {} },
     Setting:new{ id = 'context_field' },

--- a/ankinote.lua
+++ b/ankinote.lua
@@ -14,9 +14,11 @@ local AnkiNote = {
 -- We want to know if last dict lookup is contained in first dict lookup.
 -- e.g.: '広大な' -> trimmed to '広大' -> context is '' (before), 'な' (after)
 --]]
+
 function AnkiNote:set_word_trim()
     local list = self.popup_dict.window_list
-    if #list == 1 then
+    if #list == 1 or conf.trust_first_dict:get_value() then
+        self.popup_dict.word = list[1].word -- often useless
         return
     end
     local orig, last = list[1].word, list[#list].word

--- a/menubuilder.lua
+++ b/menubuilder.lua
@@ -46,6 +46,13 @@ local menu_entries = {
         conf_type = "bool",
     },
     {
+        id = "trust_first_dict",
+        group = general_settings,
+        name = "Use first lookup context",
+        description = "Blindly use word and sentence context from first lookup when doing nested lookups",
+        conf_type = "bool",
+    },
+    {
         id = "dupe_scope",
         group = general_settings,
         name = "Duplicate Scope",

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -29,6 +29,8 @@ local Config = {
     -- It is possible to toggle whether duplicate notes can be created. This can be of use if your note type contains the full sentence as first field (meaning this gets looked at for uniqueness)
     -- When multiple unknown words are present, it won't be possible to add both in this case, because the sentence would be the same.
     allow_dupes = false,
+    -- When adding words within nested windows (like a dictionary lookup from a dictionary window), take original lookup as word
+    trust_first_dict = false,
     -- The scope where ankiconnect will look to to find duplicates
     dupe_scope = "deck",
     -- api key - extra authentication supported by ankiconnect, see https://git.foosoft.net/alex/anki-connect#authentication


### PR DESCRIPTION
This pr adds an option to make all lookups contextual

When I'm using the addon for a language like french, I'll often first lookup a conjugated verb, which pulls up a dictionary entry just mentioning the tense and the original verb, and I'll then do a second lookup on the original verb in the first lookup's dictionary. If the conjugated verb is a substring of the unconjugated verb, then the original context is preserved, otherwise it is lost. 

This may be a niche edge case but was still frustrating enough for me to make my own fork; unsure if these changes will be deemed necessary by the maintainers but otherwise feel free to reject 