### PR TITLE
Pick deck, note type and fields from anki-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ Configuration is done by defining profiles, See [Profiles](profiles/README.md) f
 
 When editing a profile which is *not* the default one, it's possible to 'unset' a setting (meaning it falls back on whatever is present in the `default.lua` profile). This is done by pressing and holding the setting you would like to reset.
 
+Each setting shows its configured value right in the menu label (e.g. `Word Field: Front`); settings that have no value yet are shown as `(not set)`, so it's easy to see at a glance what still needs configuring.
+
+### Picking deck, note type and fields from Anki
+
+The **Anki Deckname**, **Anki Note Type** and the various note field settings (Word, Context, Glossary, ...) no longer have to be typed out by hand. When you open one of these settings, the plugin queries the running Anki instance through anki-connect and presents the available values in a list to pick from. The currently selected value is marked with a `✓`.
+
+- The list of fields depends on the selected note type, so set the **Anki Note Type** first. The field settings stay greyed out until a note type is set.
+- This requires the anki-connect URL to be configured and Anki to be reachable (WiFi will be brought up if needed). If the list can't be fetched, you'll be informed and can still enter the value manually.
+- Every selection dialog also has an **Enter manually** button, in case you want to set a value that isn't (yet) present in Anki.
+
 ## FAQ
 
 <details>

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The **Anki Deckname**, **Anki Note Type** and the various note field settings (W
 - This requires the anki-connect URL to be configured and Anki to be reachable (WiFi will be brought up if needed). If the list can't be fetched, you'll be informed and can still enter the value manually.
 - Every selection dialog also has an **Enter manually** button, in case you want to set a value that isn't (yet) present in Anki.
 
+**Duplicate Scope** is also picked from a list, but a fixed one (no anki-connect lookup): `deck` checks for duplicates only within the target deck, `collection` checks across the whole collection.
+
 ## FAQ
 
 <details>

--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -69,6 +69,16 @@ function AnkiConnect:get_decknames(url, api_key)
     return self:POST { payload = anki_connect_request, url = url }
 end
 
+function AnkiConnect:get_modelnames(url, api_key)
+    local anki_connect_request = { action = "modelNames", version = 6, key = api_key }
+    return self:POST { payload = anki_connect_request, url = url }
+end
+
+function AnkiConnect:get_model_field_names(url, api_key, model_name)
+    local anki_connect_request = { action = "modelFieldNames", version = 6, key = api_key, params = { modelName = model_name } }
+    return self:POST { payload = anki_connect_request, url = url }
+end
+
 function AnkiConnect:request_add_note(note)
     local anki_connect_request = { action = "addNote", params = { note = note }, version = 6, key = conf.api_key:get_value() }
     return self:POST { payload = anki_connect_request, url = conf.url:get_value() }

--- a/menubuilder.lua
+++ b/menubuilder.lua
@@ -44,8 +44,9 @@ local menu_entries = {
         id = "dupe_scope",
         group = general_settings,
         name = "Duplicate Scope",
-        description = "Anki Scope in which to look for duplicates",
-        conf_type = "text",
+        description = "Anki scope in which to look for duplicates: within the target deck, or across the whole collection.",
+        conf_type = "select",
+        choices = { "deck", "collection" },
     },
      {
         id = "custom_tags",
@@ -277,7 +278,7 @@ function MenuConfigOpt:fetch_choices()
     return true, result
 end
 
-function MenuConfigOpt:show_choice_dialog(choices, touchmenu_instance)
+function MenuConfigOpt:show_choice_dialog(choices, touchmenu_instance, allow_manual)
     table.sort(choices)
     local current = self:get_value_nodefault()
     local choice_dialog
@@ -294,13 +295,16 @@ function MenuConfigOpt:show_choice_dialog(choices, touchmenu_instance)
             end,
         }})
     end
-    table.insert(buttons, {{
-        text = "Enter manually",
-        callback = function()
-            UIManager:close(choice_dialog)
-            self:build_single_dialog(touchmenu_instance)
-        end,
-    }})
+    -- API-backed lists can be incomplete, so allow typing a value; fixed enums don't need it
+    if allow_manual ~= false then
+        table.insert(buttons, {{
+            text = "Enter manually",
+            callback = function()
+                UIManager:close(choice_dialog)
+                self:build_single_dialog(touchmenu_instance)
+            end,
+        }})
+    end
     choice_dialog = ButtonDialog:new{
         title = self.name,
         title_align = "center",
@@ -311,6 +315,10 @@ function MenuConfigOpt:show_choice_dialog(choices, touchmenu_instance)
 end
 
 function MenuConfigOpt:build_select_dialog(touchmenu_instance)
+    -- fixed set of choices (e.g. dupe_scope): no anki-connect lookup needed
+    if self.choices then
+        return self:show_choice_dialog({ unpack(self.choices) }, touchmenu_instance, false)
+    end
     local function run()
         local ok, choices_or_err = self:fetch_choices()
         if not ok then

--- a/menubuilder.lua
+++ b/menubuilder.lua
@@ -3,9 +3,12 @@ local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
+local ButtonDialog = require("ui/widget/buttondialog")
+local NetworkMgr = require("ui/network/manager")
 local util = require("util")
 local List = require("lua_utils.list")
 local config = require("anki_configuration")
+local AnkiConnect = require("ankiconnect")
 
 local general_settings = { "generic_settings", "General Settings" }
 local note_settings = { "note_settings", "Anki Note Settings" }
@@ -19,12 +22,16 @@ local menu_entries = {
         group = general_settings,
         name = "Anki Deckname",
         description = "The name of the deck the new notes should be added to.",
+        conf_type = "select",
+        select_kind = "decks",
     },
      {
         id = "modelName",
         group = general_settings,
         name = "Anki Note Type",
         description = "The Anki note type our cards should use.",
+        conf_type = "select",
+        select_kind = "models",
     },
      {
         id = "allow_dupes",
@@ -52,42 +59,56 @@ local menu_entries = {
         group = note_settings,
         name = "Word Field",
         description = "Anki field for selected word.",
+        conf_type = "select",
+        select_kind = "fields",
     },
      {
         id = "context_field",
         group = note_settings,
         name = "Context Field",
         description = "Anki field for sentence selected word occured in.",
+        conf_type = "select",
+        select_kind = "fields",
     },
     {
         id = "translated_context_field",
         group = note_settings,
         name = "Translated Context Field",
-        description = "Anki Field for the translation of the sentence the selected word occured in."
+        description = "Anki Field for the translation of the sentence the selected word occured in.",
+        conf_type = "select",
+        select_kind = "fields",
     },
      {
         id = "def_field",
         group = note_settings,
         name = "Glossary Field",
         description = "Anki field for dictionary glossary.",
+        conf_type = "select",
+        select_kind = "fields",
     },
      {
         id = "meta_field",
         group = note_settings,
         name = "Metadata Field",
         description = "Anki field to store metadata about the current book.",
+        conf_type = "select",
+        select_kind = "fields",
     },
      {
         id = "audio_field",
         group = note_settings,
         name = "Forvo Audio Field",
         description = "Anki field to store Forvo audio in.",
+        conf_type = "select",
+        select_kind = "fields",
     },
      {
-        id = "img_field",
+        id = "image_field",
         group = note_settings,
         name = "Image Field",
         description = "Anki field to store image in (used for CBZ only).",
+        conf_type = "select",
+        select_kind = "fields",
     },
     {
         id = "enabled_extensions",
@@ -102,12 +123,14 @@ local menu_entries = {
         group = note_settings,
         name = "Previous Sentence Count",
         description = "Amount of sentences to prepend to the word looked up.",
+        conf_type = "number",
     },
     {
         id = "next_sentence_count",
         group = note_settings,
         name = "Next Sentence Count",
         description = "Amount of sentences to append to the word looked up.",
+        conf_type = "number",
     },
     --[[ TODO: we may wanna move this to the extension and insert it back in the menu somehow
      {
@@ -142,12 +165,13 @@ function MenuConfigOpt:new(o)
     return setmetatable(new_, { __index = index })
 end
 
-function MenuBuilder.build_single_dialog(title, input, hint, description, callback)
+function MenuBuilder.build_single_dialog(title, input, hint, description, callback, input_type)
     local input_dialog -- saved first so we can reference it in the callbacks
     input_dialog = InputDialog:new {
         title = title,
         input = tostring(input),
         input_hint = hint,
+        input_type = input_type,
         description = description,
         buttons = {{
             { text = "Cancel",  id = "cancel",      callback = function() UIManager:close(input_dialog) end },
@@ -157,17 +181,152 @@ function MenuBuilder.build_single_dialog(title, input, hint, description, callba
     return input_dialog
 end
 
-function MenuConfigOpt:build_single_dialog()
+-- redraw the menu so text_func/checked_func reflect the just-changed value
+local function refresh_menu(touchmenu_instance)
+    if touchmenu_instance then touchmenu_instance:updateItems() end
+end
+
+function MenuConfigOpt:build_single_dialog(touchmenu_instance)
     local callback = function(dialog)
         self:update_value(dialog:getInputText())
         UIManager:close(dialog)
+        refresh_menu(touchmenu_instance)
     end
     local input_dialog = MenuBuilder.build_single_dialog(self.name, self:get_value_nodefault() or '', self.name, self.description, callback)
     UIManager:show(input_dialog)
     input_dialog:onShowKeyboard()
 end
 
-function MenuConfigOpt:build_multi_dialog()
+-- string representation of the currently configured value, or nil when nothing is set
+function MenuConfigOpt:display_value()
+    local v = self:get_value_nodefault()
+    if v == nil then return nil end
+    if type(v) == "table" then
+        return #v > 0 and table.concat(v, ", ") or nil
+    end
+    if type(v) == "string" and #v == 0 then return nil end
+    return tostring(v)
+end
+
+-- menu label showing the configured value, so set entries stand out from empty ones
+function MenuConfigOpt:menu_label()
+    return ("%s: %s"):format(self.name, self:display_value() or "(not set)")
+end
+
+function MenuConfigOpt:build_number_dialog(touchmenu_instance)
+    local input_dialog
+    local callback = function(dialog)
+        local text = dialog:getInputText()
+        if #text == 0 then
+            -- empty input unsets the value, falling back to the default (same as text fields)
+            self:update_value("")
+            UIManager:close(dialog)
+            return refresh_menu(touchmenu_instance)
+        end
+        local n = tonumber(text)
+        if not n or n < 0 or n ~= math.floor(n) then
+            return UIManager:show(InfoMessage:new {
+                text = "Please enter a whole number (0 or greater).",
+                timeout = 3,
+            })
+        end
+        self:update_value(n)
+        UIManager:close(dialog)
+        refresh_menu(touchmenu_instance)
+    end
+    local current = self:get_value_nodefault()
+    input_dialog = MenuBuilder.build_single_dialog(self.name, current ~= nil and tostring(current) or "", self.name, self.description, callback, "number")
+    UIManager:show(input_dialog)
+    input_dialog:onShowKeyboard()
+end
+
+-- reads another setting of the same profile this option belongs to
+function MenuConfigOpt:get_sibling_value(id)
+    return config[id]:copy{ active_luasettings = self.active_luasettings }:get_value_nodefault()
+end
+
+-- fetches the list of valid values for this option from anki-connect
+-- returns (true, list) on success, (false, error_message) otherwise
+function MenuConfigOpt:fetch_choices()
+    local url = config.url:get_value()
+    if not url or #url == 0 then
+        return false, "The anki-connect URL is not configured yet."
+    end
+    local api_key = config.api_key:get_value()
+    local can_run, err = AnkiConnect:is_running(url)
+    if not can_run then
+        return false, err
+    end
+    local result, request_err
+    if self.select_kind == "decks" then
+        result, request_err = AnkiConnect:get_decknames(url, api_key)
+    elseif self.select_kind == "models" then
+        result, request_err = AnkiConnect:get_modelnames(url, api_key)
+    elseif self.select_kind == "fields" then
+        local model = self:get_sibling_value("modelName")
+        if not model or #model == 0 then
+            return false, "Set the Anki Note Type first, then the available fields can be listed."
+        end
+        result, request_err = AnkiConnect:get_model_field_names(url, api_key, model)
+    else
+        return false, ("Unknown select kind: %s"):format(tostring(self.select_kind))
+    end
+    if request_err then
+        return false, request_err
+    end
+    return true, result
+end
+
+function MenuConfigOpt:show_choice_dialog(choices, touchmenu_instance)
+    table.sort(choices)
+    local current = self:get_value_nodefault()
+    local choice_dialog
+    local buttons = {}
+    for _, choice in ipairs(choices) do
+        local prefix = choice == current and "✓ " or ""
+        table.insert(buttons, {{
+            text = prefix .. choice,
+            align = "left",
+            callback = function()
+                self:update_value(choice)
+                UIManager:close(choice_dialog)
+                refresh_menu(touchmenu_instance)
+            end,
+        }})
+    end
+    table.insert(buttons, {{
+        text = "Enter manually",
+        callback = function()
+            UIManager:close(choice_dialog)
+            self:build_single_dialog(touchmenu_instance)
+        end,
+    }})
+    choice_dialog = ButtonDialog:new{
+        title = self.name,
+        title_align = "center",
+        buttons = buttons,
+        rows_per_page = 12,
+    }
+    UIManager:show(choice_dialog)
+end
+
+function MenuConfigOpt:build_select_dialog(touchmenu_instance)
+    local function run()
+        local ok, choices_or_err = self:fetch_choices()
+        if not ok then
+            UIManager:show(InfoMessage:new {
+                text = ("Could not load the list from Anki:\n%s\n\nYou can enter the value manually instead."):format(choices_or_err),
+                timeout = 5,
+            })
+            return self:build_single_dialog(touchmenu_instance)
+        end
+        self:show_choice_dialog(choices_or_err, touchmenu_instance)
+    end
+    if NetworkMgr:willRerunWhenOnline(function() run() end) then return end
+    run()
+end
+
+function MenuConfigOpt:build_multi_dialog(touchmenu_instance)
     local fields = {}
     for k,v in pairs(self:get_value_nodefault() or {}) do
         table.insert(fields, { description = k, text = v })
@@ -187,6 +346,7 @@ function MenuConfigOpt:build_multi_dialog()
                 end
                 self:update_value(new)
                 UIManager:close(multi_dialog)
+                refresh_menu(touchmenu_instance)
             end},
             }
         },
@@ -195,7 +355,7 @@ function MenuConfigOpt:build_multi_dialog()
     multi_dialog:onShowKeyboard()
 end
 
-function MenuConfigOpt:build_list_dialog()
+function MenuConfigOpt:build_list_dialog(touchmenu_instance)
     local callback = function(dialog)
         local new_tags = {}
         for tag in util.gsplit(dialog:getInputText(), ",") do
@@ -203,6 +363,7 @@ function MenuConfigOpt:build_list_dialog()
         end
         self:update_value(new_tags)
         UIManager:close(dialog)
+        refresh_menu(touchmenu_instance)
     end
     local description = self.description.."\nMultiple values can be listed, separated by a comma."
     local input_dialog = MenuBuilder.build_single_dialog(self.name,table.concat(self:get_value_nodefault() or {}, ","), self.name, description, callback)
@@ -338,30 +499,51 @@ function MenuBuilder:convert_opt(opt)
         text = opt.name,
         keep_menu_open = true,
         --enabled_func = function() return opt.enabled end,
-        hold_callback = function()
+        hold_callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
                 text = "Do you want to delete this setting from the current profile?",
                 ok_callback = function()
                     opt:delete()
+                    refresh_menu(touchmenu_instance)
                 end
             })
         end
     }
     if opt.conf_type == "text" then
-        sub_item_entry['callback'] = function() return opt:build_single_dialog() end
+        sub_item_entry['callback'] = function(touchmenu_instance) return opt:build_single_dialog(touchmenu_instance) end
+    elseif opt.conf_type == "number" then
+        sub_item_entry['callback'] = function(touchmenu_instance) return opt:build_number_dialog(touchmenu_instance) end
+    elseif opt.conf_type == "select" then
+        if opt.select_kind == "fields" then
+            -- field names depend on the chosen note type, so keep these greyed out until it's set
+            sub_item_entry['enabled_func'] = function()
+                local model = opt:get_sibling_value("modelName")
+                return model ~= nil and #model > 0
+            end
+        end
+        sub_item_entry['callback'] = function(touchmenu_instance) return opt:build_select_dialog(touchmenu_instance) end
     elseif opt.conf_type == "table" then
-        sub_item_entry['callback'] = function() return opt:build_multi_dialog() end
+        sub_item_entry['callback'] = function(touchmenu_instance) return opt:build_multi_dialog(touchmenu_instance) end
     elseif opt.conf_type == "bool" then
         sub_item_entry['checked_func'] = function() return opt:get_value_nodefault() == true end
-        sub_item_entry['callback'] = function() return opt:update_value(not opt:get_value_nodefault()) end
+        sub_item_entry['callback'] = function(touchmenu_instance)
+            opt:update_value(not opt:get_value_nodefault())
+            refresh_menu(touchmenu_instance)
+        end
     elseif opt.conf_type == "list" then
-        sub_item_entry['callback'] = function() return opt:build_list_dialog() end
+        sub_item_entry['callback'] = function(touchmenu_instance) return opt:build_list_dialog(touchmenu_instance) end
     elseif opt.conf_type == "checklist" then
         sub_item_entry['sub_item_table'] = opt:build_checklist()
     elseif opt.conf_type == "map" then
         sub_item_entry['sub_item_table'] = opt:build_map_dialog()
     else -- TODO multitable
         sub_item_entry['enabled_func'] = function() return false end
+    end
+    -- for value-bearing entries, show the configured value in the label so set entries are
+    -- distinguishable from empty ones (bool already shows its state via the checkbox)
+    local value_types = { text = true, number = true, select = true, list = true }
+    if value_types[opt.conf_type] then
+        sub_item_entry['text_func'] = function() return opt:menu_label() end
     end
     return sub_item_entry
 end


### PR DESCRIPTION
## What

Configuring a profile currently means typing the deck name, note type and every field name by hand, which is error-prone (a typo silently produces broken notes). This PR lets the user **pick those values from a list fetched through anki-connect** instead.

When you open one of these settings, the plugin queries the running Anki instance and shows the available values in a scrollable `ButtonDialog` to choose from; the current value is marked with `✓`.

- **Deck** → `deckNames`
- **Note type** → `modelNames`
- **Fields** (Word, Context, Glossary, ...) → `modelFieldNames` for the selected note type

Three small `AnkiConnect` helpers were added for this (`get_modelnames`, `get_model_field_names`, reusing the existing `get_decknames` pattern).

## UX details

- Field settings depend on the chosen note type, so they stay **greyed out until a note type is set**, and the list is fetched for that specific type.
- Every selection dialog has an **"Enter manually"** button, and if Anki can't be reached the plugin shows why and falls back to a manual text entry — so nothing is lost when offline.
- Each setting now shows its **configured value right in the menu label** (e.g. `Word Field: Front`), or `(not set)` when empty, so it's obvious at a glance what still needs configuring. The menu refreshes in place (`updateItems`) when a value changes.
- **Previous/Next sentence count** now use a validated numeric input dialog (numeric keyboard, whole numbers only) instead of free text — these are consumed via `tonumber`, and non-numeric input could previously produce `nil` and crash the custom-context menu.

## Drive-by fix

The "Image Field" menu entry used the id `img_field`, while the underlying setting is `image_field`. Because of the mismatch the entry never appeared in the menu. The ids now match, so the image field is configurable again.

## Note on SpinWidget

For the sentence-count number input I first tried the standard `SpinWidget`, called exactly like core does (cf. `readerbookmark.lua`) and with an API identical between the release and current master. On a v2026.03 device it reliably crashed KOReader **on opening the widget** — a native `SIGABRT` (`pthread_mutex_lock called on a destroyed mutex`), with no Lua traceback to debug from. I couldn't pin down the native cause, and since the goal was simply to guarantee an integer value, I switched to a validated `InputDialog` with `input_type = "number"`, which is version-independent and crash-free. Happy to revisit `SpinWidget` if a maintainer knows what triggers that crash.

## Testing

Manually tested on a v2026.03 Android device: deck/note type/field selection from live Anki, the offline manual-entry fallback, greying-out of fields until a note type is set, numeric validation, and in-place menu label refresh.