### PR TITLE
add support for new api for adding dict buttons

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -317,6 +317,7 @@ function AnkiWidget:init()
 
     self.ui.menu:registerToMainMenu(self)
     self:handle_events()
+    self:registerDictButtons()
 end
 
 function AnkiWidget:extend_doc_settings(filepath, document_properties)
@@ -462,6 +463,32 @@ function AnkiWidget:onDictButtonsReady(popup_dict, buttons)
         end,
     }
     table.insert(buttons, 1, { self.add_to_anki_btn })
+end
+
+function AnkiWidget:registerDictButtons()
+    if not self.ui or not self.ui.dictionary then return end
+    self.ui.dictionary:addToDictButtons({
+          id = "add_to_anki",
+          text = _("Add to Anki"),
+          menu_text = _("Anki"),
+          font_bold = true,
+          callback = function(popup_dict)
+              self:set_profile(function()
+                  self:check_conn(function()
+                      self.current_note = AnkiNote:new(popup_dict)
+                      AnkiConnect:add_note(self.current_note)
+                  end)
+              end)
+          end,
+          hold_callback = function(popup_dict)
+              self:set_profile(function()
+                  self:check_conn(function()
+                      self.current_note = AnkiNote:new(popup_dict)
+                      self:show_config_widget()
+                  end)
+              end)
+          end,
+    })
 end
 
 return AnkiWidget


### PR DESCRIPTION
This fixes https://github.com/Ajatt-Tools/anki.koplugin/issues/96
By using the new dict popup button API added https://github.com/koreader/koreader/pull/15184l

I kept the 2 old APIs (event based, and the even older function based) because that
seems to be what is needed to maintain backwards compatibility.
