### PR TITLE
Improved audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,13 @@ These settings are configured via a user profile, see [Profiles](profiles/README
   
   #### Dictionary definition (`def_field`)
   The dictionary entry that was selected when pressing the button.
-  #### Audio (`audio_field`)
-  The plugin will query Forvo to get audio for the lookupword. The language used is determined by the dictionary's language, or by the book's language as fallback.
+  #### Audio (`audio_field` / `audio_driver`)
+  When an audio field and driver are configured, the plugin fetches pronunciation audio for the looked-up word and attaches it to the note.
+
+  - `audio_field` — Anki field that receives the audio
+  - `audio_driver` — which source to use (`forvo` by default, or `none` to skip). Additional drivers can be added under [`audio_drivers/`](audio_drivers/README.md).
+
+  The language used is determined by the dictionary's language, or by the book's language as fallback. Drivers may return either a remote URL or base64-encoded audio data for AnkiConnect.
   #### Metadata (`meta_field`)
   Some information about the book: author, title and page number.
   
@@ -109,7 +114,7 @@ When editing a profile which is *not* the default one, it's possible to 'unset' 
 
 <details>
   <summary>Plugin can't detect the language of the word</summary> 
-  When the user has defined a value for the `audio_field` in the config, the plugin needs to know the language of the word you looked up, so it can look for the correct audio file.
+  When the user has defined a value for the `audio_field` and selected an audio driver other than `none`, the plugin needs to know the language of the word you looked up, so it can look for the correct audio file.
 
 
   It looks for this language in 2 places
@@ -138,6 +143,6 @@ When editing a profile which is *not* the default one, it's possible to 'unset' 
   
     The expected format of this language is, like above, the ISO2 code. For example, to specify French, fill in 'fr'
   
-  If you don't care about having audio, you can leave the `audio_field` blank. This will cause this step to be skipped completely.
+  If you don't care about having audio, leave the `audio_field` blank or set `audio_driver` to `none`. This will cause this step to be skipped completely.
     
 </details>

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ These settings are configured via a user profile, see [Profiles](profiles/README
   
   #### Dictionary definition (`def_field`)
   The dictionary entry that was selected when pressing the button.
-  #### Audio (`audio_field` / `sentence_audio_field` / drivers)
+  #### Audio (`word_audio_field` / `sentence_audio_field` / drivers)
   When audio fields and drivers are configured, the plugin fetches pronunciation audio and attaches it to the note.
 
-  - `audio_field` — Anki field that receives **word** audio
+  - `word_audio_field` — Anki field that receives **word** audio (falls back to legacy `audio_field` if unset)
   - `sentence_audio_field` — Anki field that receives **sentence** audio
   - `word_audio_driver` / `sentence_audio_driver` — source to use (`forvo` by default for word, `none` for sentence). Set to `none` to skip. Additional drivers can be added under [`audio_drivers/`](audio_drivers/README.md).
   - `word_audio_driver_settings` / `sentence_audio_driver_settings` — per-driver options (e.g. VOICEVOX URL)
@@ -118,7 +118,7 @@ When editing a profile which is *not* the default one, it's possible to 'unset' 
 
 <details>
   <summary>Plugin can't detect the language of the word</summary> 
-  When the user has defined a value for `audio_field` or `sentence_audio_field` and selected an audio driver other than `none`, the plugin needs to know the language of the word you looked up, so it can look for the correct audio file.
+  When the user has defined a value for `word_audio_field` (or legacy `audio_field`) or `sentence_audio_field` and selected an audio driver other than `none`, the plugin needs to know the language of the word you looked up, so it can look for the correct audio file.
 
 
   It looks for this language in 2 places

--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@ These settings are configured via a user profile, see [Profiles](profiles/README
   
   #### Dictionary definition (`def_field`)
   The dictionary entry that was selected when pressing the button.
-  #### Audio (`audio_field` / `audio_driver`)
-  When an audio field and driver are configured, the plugin fetches pronunciation audio for the looked-up word and attaches it to the note.
+  #### Audio (`audio_field` / `sentence_audio_field` / drivers)
+  When audio fields and drivers are configured, the plugin fetches pronunciation audio and attaches it to the note.
 
-  - `audio_field` — Anki field that receives the audio
-  - `audio_driver` — which source to use (`forvo` by default, or `none` to skip). Additional drivers can be added under [`audio_drivers/`](audio_drivers/README.md).
+  - `audio_field` — Anki field that receives **word** audio
+  - `sentence_audio_field` — Anki field that receives **sentence** audio
+  - `word_audio_driver` / `sentence_audio_driver` — source to use (`forvo` by default for word, `none` for sentence). Set to `none` to skip. Additional drivers can be added under [`audio_drivers/`](audio_drivers/README.md).
+  - `word_audio_driver_settings` / `sentence_audio_driver_settings` — per-driver options (e.g. VOICEVOX URL)
+
+  In the KOReader menu these live under **General Settings → Audio → Word Audio / Sentence Audio**.
 
   The language used is determined by the dictionary's language, or by the book's language as fallback. Drivers may return either a remote URL or base64-encoded audio data for AnkiConnect.
   #### Metadata (`meta_field`)
@@ -114,7 +118,7 @@ When editing a profile which is *not* the default one, it's possible to 'unset' 
 
 <details>
   <summary>Plugin can't detect the language of the word</summary> 
-  When the user has defined a value for the `audio_field` and selected an audio driver other than `none`, the plugin needs to know the language of the word you looked up, so it can look for the correct audio file.
+  When the user has defined a value for `audio_field` or `sentence_audio_field` and selected an audio driver other than `none`, the plugin needs to know the language of the word you looked up, so it can look for the correct audio file.
 
 
   It looks for this language in 2 places
@@ -143,6 +147,6 @@ When editing a profile which is *not* the default one, it's possible to 'unset' 
   
     The expected format of this language is, like above, the ISO2 code. For example, to specify French, fill in 'fr'
   
-  If you don't care about having audio, leave the `audio_field` blank or set `audio_driver` to `none`. This will cause this step to be skipped completely.
+  If you don't care about having audio, leave the audio fields blank or set the drivers to `none`. This will cause this step to be skipped completely.
     
 </details>

--- a/anki_configuration.lua
+++ b/anki_configuration.lua
@@ -78,6 +78,8 @@ local Configuration = {
     Setting:new{ id = 'context_field' },
     Setting:new{ id = 'meta_field' },
     Setting:new{ id = 'audio_field' },
+    Setting:new{ id = 'audio_driver', default = 'forvo' },
+    Setting:new{ id = 'audio_driver_settings', default = {} },
     Setting:new{ id = 'image_field' },
     Setting:new{ id = 'translated_context_field' },
     Setting:new{ id = 'prev_sentence_count', default = '1' },
@@ -85,6 +87,12 @@ local Configuration = {
 }
 for _,s in ipairs(Configuration) do
     Configuration[s.id] = s
+end
+
+--- Return the settings table for a given audio driver id (from the active profile).
+function Configuration:get_audio_driver_settings(driver_id)
+    local all = self.audio_driver_settings:get_value() or {}
+    return all[driver_id] or {}
 end
 
 local plugin_directory = DataStorage:getFullDataDir() .. "/plugins/anki.koplugin/"

--- a/anki_configuration.lua
+++ b/anki_configuration.lua
@@ -77,7 +77,8 @@ local Configuration = {
     Setting:new{ id = 'enabled_extensions', default = {} },
     Setting:new{ id = 'context_field' },
     Setting:new{ id = 'meta_field' },
-    Setting:new{ id = 'audio_field' },
+    Setting:new{ id = 'audio_field' }, -- legacy alias for word_audio_field
+    Setting:new{ id = 'word_audio_field' },
     Setting:new{ id = 'sentence_audio_field' },
     Setting:new{ id = 'word_audio_driver', default = 'forvo' },
     Setting:new{ id = 'word_audio_driver_settings', default = {} },
@@ -90,6 +91,15 @@ local Configuration = {
 }
 for _,s in ipairs(Configuration) do
     Configuration[s.id] = s
+end
+
+--- Word audio Anki field. Prefers word_audio_field; falls back to legacy audio_field.
+function Configuration:get_word_audio_field()
+    local field = self.word_audio_field:get_value()
+    if field and field ~= "" then
+        return field
+    end
+    return self.audio_field:get_value()
 end
 
 --- Word audio driver id.

--- a/anki_configuration.lua
+++ b/anki_configuration.lua
@@ -78,8 +78,11 @@ local Configuration = {
     Setting:new{ id = 'context_field' },
     Setting:new{ id = 'meta_field' },
     Setting:new{ id = 'audio_field' },
-    Setting:new{ id = 'audio_driver', default = 'forvo' },
-    Setting:new{ id = 'audio_driver_settings', default = {} },
+    Setting:new{ id = 'sentence_audio_field' },
+    Setting:new{ id = 'word_audio_driver', default = 'forvo' },
+    Setting:new{ id = 'word_audio_driver_settings', default = {} },
+    Setting:new{ id = 'sentence_audio_driver', default = 'none' },
+    Setting:new{ id = 'sentence_audio_driver_settings', default = {} },
     Setting:new{ id = 'image_field' },
     Setting:new{ id = 'translated_context_field' },
     Setting:new{ id = 'prev_sentence_count', default = '1' },
@@ -89,9 +92,23 @@ for _,s in ipairs(Configuration) do
     Configuration[s.id] = s
 end
 
---- Return the settings table for a given audio driver id (from the active profile).
-function Configuration:get_audio_driver_settings(driver_id)
-    local all = self.audio_driver_settings:get_value() or {}
+--- Word audio driver id.
+function Configuration:get_word_audio_driver()
+    return self.word_audio_driver:get_value()
+end
+
+--- Sentence audio driver id.
+function Configuration:get_sentence_audio_driver()
+    return self.sentence_audio_driver:get_value()
+end
+
+--- Return the settings table for a given audio driver id.
+-- @param driver_id string
+-- @param kind "word"|"sentence" (default "word")
+function Configuration:get_audio_driver_settings(driver_id, kind)
+    kind = kind or "word"
+    local setting = kind == "sentence" and self.sentence_audio_driver_settings or self.word_audio_driver_settings
+    local all = setting:get_value() or {}
     return all[driver_id] or {}
 end
 

--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -46,8 +46,19 @@ function AnkiConnect.sanitize_url(url)
     return valid_url, ssl ~= nil
 end
 
-function AnkiConnect.with_timeout(timeout, func)
-    socketutil:set_timeout(timeout)
+-- Light requests (connectivity / deck names): keep UI snappy when Anki is down.
+local POST_BLOCK_TIMEOUT = 1
+-- Media-heavy requests (addNote with base64 audio/images): match VoiceVox LARGE timeouts.
+local POST_LARGE_BLOCK_TIMEOUT = socketutil.LARGE_BLOCK_TIMEOUT
+local POST_LARGE_TOTAL_TIMEOUT = socketutil.LARGE_TOTAL_TIMEOUT
+
+function AnkiConnect.with_timeout(block_timeout, total_timeout_or_func, func)
+    -- Supports with_timeout(block, func) and with_timeout(block, total, func).
+    if type(total_timeout_or_func) == "function" then
+        func = total_timeout_or_func
+        total_timeout_or_func = nil
+    end
+    socketutil:set_timeout(block_timeout, total_timeout_or_func)
     local res = { func() } -- store all values returned by function
     socketutil:reset_timeout()
     return unpack(res)
@@ -72,7 +83,12 @@ end
 
 function AnkiConnect:request_add_note(note)
     local anki_connect_request = { action = "addNote", params = { note = note }, version = 6, key = conf.api_key:get_value() }
-    return self:POST { payload = anki_connect_request, url = conf.url:get_value() }
+    return self:POST {
+        payload = anki_connect_request,
+        url = conf.url:get_value(),
+        block_timeout = POST_LARGE_BLOCK_TIMEOUT,
+        total_timeout = POST_LARGE_TOTAL_TIMEOUT,
+    }
 end
 
 function AnkiConnect:POST(opts)
@@ -102,7 +118,11 @@ function AnkiConnect:POST(opts)
         source = ltn12.source.string(payload)
     }
     logger.dbg("AnkiConnect#POST request:", req)
-    local status_code, response_headers, status = self.with_timeout(1, function() return socket.skip(1, http.request(req)) end)
+    local block_timeout = opts.block_timeout or POST_BLOCK_TIMEOUT
+    local total_timeout = opts.total_timeout
+    local status_code, response_headers, status = self.with_timeout(block_timeout, total_timeout, function()
+        return socket.skip(1, http.request(req))
+    end)
     logger.dbg("AnkiConnect#POST response:", status_code, response_headers, status)
 
     if type(status_code) == "string" then return nil, status_code end
@@ -149,32 +169,36 @@ function AnkiConnect:normalize_audio_payload(field, result)
     return true, audio
 end
 
-function AnkiConnect:set_note_audio(field, word, language, driver_id, fields)
+function AnkiConnect:set_note_audio(field, word, language, driver_id, fields, kind)
     if not driver_id or driver_id == "none" then
+        return true, nil
+    end
+    if not word or word == "" then
         return true, nil
     end
     local driver = AudioDrivers:get(driver_id)
     if not driver then
         return false, ("Unknown audio driver: %s"):format(driver_id)
     end
-    logger.info(("Querying audio via driver '%s' for '%s' in language: %s"):format(driver_id, word, language))
+    kind = kind or "word"
+    logger.info(("Querying %s audio via driver '%s' for '%s' in language: %s"):format(kind, driver_id, word, language))
     local ok, result = driver:get_audio({
         word = word,
         language = language,
         field = field,
         fields = fields or {},
-        settings = conf:get_audio_driver_settings(driver_id),
+        settings = conf:get_audio_driver_settings(driver_id, kind),
     })
     if not ok then
         return false, result
     end
     if not result then
-        logger.warn(("Audio driver '%s' returned no audio for '%s' - note will be created without audio"):format(driver_id, word))
+        logger.warn(("Audio driver '%s' returned no audio for '%s' - note will be created without %s audio"):format(driver_id, word, kind))
         return true, nil
     end
     local norm_ok, audio_or_err = self:normalize_audio_payload(field, result)
     if norm_ok then
-        logger.info(("Audio attached via '%s' (%s)"):format(driver_id, audio_or_err.url and "url" or "data"))
+        logger.info(("%s audio attached via '%s' (%s)"):format(kind, driver_id, audio_or_err.url and "url" or "data"))
     end
     return norm_ok, audio_or_err
 end
@@ -208,6 +232,18 @@ function AnkiConnect:handle_callbacks(note, on_err_func)
             end
             if param == "fields" then
                 note.data.fields[mod.field_name] = result_or_err
+            elseif param == "word_audio" or param == "sentence_audio" or param == "audio" then
+                -- AnkiConnect accepts a single audio object or an array of them.
+                if result_or_err then
+                    if note.data.audio == nil then
+                        note.data.audio = result_or_err
+                    else
+                        if note.data.audio.url or note.data.audio.data then
+                            note.data.audio = { note.data.audio }
+                        end
+                        table.insert(note.data.audio, result_or_err)
+                    end
+                end
             else
                 assert(note.data[param] == nil, ("unexpected result: note property '%s' was already present!"):format(param))
                 note.data[param] = result_or_err
@@ -329,15 +365,21 @@ function AnkiConnect:delete_latest_note()
     self.latest_synced_note = nil
 end
 
+--- Add a note to Anki (or store offline if unreachable).
+-- @return true on online success, "offline" when stored locally, false on failure
 function AnkiConnect:add_note(anki_note)
     local ok, note = pcall(anki_note.build, anki_note)
     if not ok then
-        return self:show_popup(string.format("Error while creating note:\n\n%s", note), 10, true)
+        self:show_popup(string.format("Error while creating note:\n\n%s", note), 10, true)
+        return false
     end
 
     local can_sync, err = self:is_running(conf.url:get_value())
     if not can_sync then
-        return self:store_offline(note, err)
+        if self:store_offline(note, err) then
+            return "offline"
+        end
+        return false
     end
 
     if #self.local_notes > 0 then
@@ -353,27 +395,31 @@ function AnkiConnect:add_note(anki_note)
     local callback_ok = self:handle_callbacks(note, function(callback_err)
         return self:show_popup(string.format("Error while handling callbacks:\n\n%s", callback_err), 3, true)
     end)
-    if not callback_ok then return end
+    if not callback_ok then return false end
 
     local result, request_err = self:request_add_note(note.data)
     if request_err then
-        return self:show_popup(string.format("Error while synchronizing note:\n\n%s", request_err), 3, true)
+        self:show_popup(string.format("Error while synchronizing note:\n\n%s", request_err), 3, true)
+        return false
     end
     self.latest_synced_note = { state = "online", id = result }
     self.last_message_text = "" -- if we manage to sync once, a following error should be shown again
     logger.info("note added succesfully: " .. result)
+    return true
 end
 
 function AnkiConnect:store_offline(note, reason, show_always)
     local id = note.data.fields[note.identifier]
     if self.local_notes[id] and not note.data.options.allowDuplicate then
-        return self:show_popup("Cannot store duplicate note offline!", 6, true)
+        self:show_popup("Cannot store duplicate note offline!", 6, true)
+        return false
     end
     self.local_notes[id] = true
     table.insert(self.local_notes, note)
     u.open_file(self.notes_filename, 'a', function(f) f:write(json.encode(note) .. '\n') end)
     self.latest_synced_note = { state = "offline", id = id }
-    return self:show_popup(string.format("%s\nStored note offline", reason), 3, show_always or false)
+    self:show_popup(string.format("%s\nStored note offline", reason), 3, show_always or false)
+    return true
 end
 
 function AnkiConnect:load_notes()

--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -149,7 +149,7 @@ function AnkiConnect:normalize_audio_payload(field, result)
     return true, audio
 end
 
-function AnkiConnect:set_note_audio(field, word, language, driver_id)
+function AnkiConnect:set_note_audio(field, word, language, driver_id, fields)
     if not driver_id or driver_id == "none" then
         return true, nil
     end
@@ -162,6 +162,7 @@ function AnkiConnect:set_note_audio(field, word, language, driver_id)
         word = word,
         language = language,
         field = field,
+        fields = fields or {},
         settings = conf:get_audio_driver_settings(driver_id),
     })
     if not ok then

--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -12,7 +12,8 @@ local InfoMessage = require("ui/widget/infomessage")
 local NetworkMgr = require("ui/network/manager")
 local DataStorage = require("datastorage")
 local Translator = require("ui/translator")
-local forvo = require("forvo")
+local base64 = require("lua_utils/base64")
+local AudioDrivers = require("audio_drivers")
 local u = require("lua_utils/utils")
 local conf = require("anki_configuration")
 
@@ -89,7 +90,7 @@ function AnkiConnect:POST(opts)
     local url = assert(opts.url, "Missing URL!")
     local scheme, basic_auth, host = url:match("^(https?://)([^:]+:[^@]+)@(.+)")
     if basic_auth then
-        headers["Authorization"] = "Basic " .. forvo.base64e(basic_auth)
+        headers["Authorization"] = "Basic " .. base64.encode(basic_auth)
         url = scheme .. host
     end
     local sink = {}
@@ -121,22 +122,60 @@ function AnkiConnect:set_translated_context(_, context)
     return true, result
 end
 
-function AnkiConnect:set_forvo_audio(field, word, language)
-    logger.info(("Querying Forvo audio for '%s' in language: %s"):format(word, language))
-    local ok, forvo_url = forvo.get_pronunciation_url(word, language)
-    if not ok then
-        if forvo_url == "FORVO_403" then
-            -- For 403 errors, return true but no audio data
-            logger.warn("Forvo returned 403 error - continuing without audio")
-            return true, nil
-        end
-        return false, ("Could not connect to forvo: %s"):format(forvo_url)
+--- Normalize a driver audio result into an AnkiConnect addNote audio object.
+-- Accepts either { url, filename } or { data, filename }. Prefers data when both are present.
+-- Returns ok, audio_or_err
+function AnkiConnect:normalize_audio_payload(field, result)
+    if type(result) ~= "table" then
+        return false, "Audio driver returned an invalid result"
     end
-    return true, forvo_url and {
-        url = forvo_url,
-        filename = string.format("forvo_%s.ogg", word),
-        fields = { field }
-    } or nil
+    if not result.filename or tostring(result.filename) == "" then
+        return false, "Audio driver result missing filename"
+    end
+    local has_data = result.data ~= nil and result.data ~= ""
+    local has_url = result.url ~= nil and result.url ~= ""
+    if not has_data and not has_url then
+        return false, "Audio driver result must include url or data"
+    end
+    local audio = {
+        filename = result.filename,
+        fields = { field },
+    }
+    if has_data then
+        audio.data = result.data
+    else
+        audio.url = result.url
+    end
+    return true, audio
+end
+
+function AnkiConnect:set_note_audio(field, word, language, driver_id)
+    if not driver_id or driver_id == "none" then
+        return true, nil
+    end
+    local driver = AudioDrivers:get(driver_id)
+    if not driver then
+        return false, ("Unknown audio driver: %s"):format(driver_id)
+    end
+    logger.info(("Querying audio via driver '%s' for '%s' in language: %s"):format(driver_id, word, language))
+    local ok, result = driver:get_audio({
+        word = word,
+        language = language,
+        field = field,
+        settings = conf:get_audio_driver_settings(driver_id),
+    })
+    if not ok then
+        return false, result
+    end
+    if not result then
+        logger.warn(("Audio driver '%s' returned no audio for '%s' - note will be created without audio"):format(driver_id, word))
+        return true, nil
+    end
+    local norm_ok, audio_or_err = self:normalize_audio_payload(field, result)
+    if norm_ok then
+        logger.info(("Audio attached via '%s' (%s)"):format(driver_id, audio_or_err.url and "url" or "data"))
+    end
+    return norm_ok, audio_or_err
 end
 
 function AnkiConnect:set_image_data(field, img_path)
@@ -148,7 +187,7 @@ function AnkiConnect:set_image_data(field, img_path)
     if not img_f then
         return true
     end
-    local data = forvo.base64e(img_f:read("*a"))
+    local data = base64.encode(img_f:read("*a"))
     logger.info(("added %d bytes of base64 encoded data"):format(#data))
     os.remove(img_path)
     return true, {

--- a/ankinote.lua
+++ b/ankinote.lua
@@ -214,9 +214,9 @@ function AnkiNote:build()
         -- some fields require an internet connection, which we may not have at this point
         -- all info needed to populate them is stored as a callback, which is called when a connection is available
         field_callbacks = {
-            audio = (function()
+            word_audio = (function()
                 local audio_field = conf.audio_field:get_value()
-                local audio_driver = conf.audio_driver:get_value()
+                local audio_driver = conf:get_word_audio_driver()
                 local language = nil
                 if audio_field and audio_driver and audio_driver ~= "none" then
                     language = self:get_language()
@@ -224,7 +224,26 @@ function AnkiNote:build()
                 return {
                     func = "set_note_audio",
                     field_name = audio_field,
-                    args = { self.popup_dict.word, language, audio_driver, note.fields }
+                    args = { self.popup_dict.word, language, audio_driver, note.fields, "word" }
+                }
+            end)(),
+            sentence_audio = (function()
+                local audio_field = conf.sentence_audio_field:get_value()
+                local audio_driver = conf:get_sentence_audio_driver()
+                local language = nil
+                local text = nil
+                if audio_field and audio_driver and audio_driver ~= "none" then
+                    language = self:get_language()
+                    local context_field = conf.context_field:get_value()
+                    text = (context_field and fields[context_field]) or self:get_word_context()
+                    if text then
+                        text = text:gsub("<[^>]+>", "")
+                    end
+                end
+                return {
+                    func = "set_note_audio",
+                    field_name = audio_field,
+                    args = { text, language, audio_driver, note.fields, "sentence" }
                 }
             end)(),
             picture = {

--- a/ankinote.lua
+++ b/ankinote.lua
@@ -207,9 +207,10 @@ function AnkiNote:build()
         },
         tags = self.tags,
     }
+    note = self:run_extensions(note)
     return {
         -- actual table passed to anki-connect later
-        data = self:run_extensions(note),
+        data = note,
         -- some fields require an internet connection, which we may not have at this point
         -- all info needed to populate them is stored as a callback, which is called when a connection is available
         field_callbacks = {
@@ -223,7 +224,7 @@ function AnkiNote:build()
                 return {
                     func = "set_note_audio",
                     field_name = audio_field,
-                    args = { self.popup_dict.word, language, audio_driver }
+                    args = { self.popup_dict.word, language, audio_driver, note.fields }
                 }
             end)(),
             picture = {

--- a/ankinote.lua
+++ b/ankinote.lua
@@ -213,11 +213,19 @@ function AnkiNote:build()
         -- some fields require an internet connection, which we may not have at this point
         -- all info needed to populate them is stored as a callback, which is called when a connection is available
         field_callbacks = {
-            audio = {
-                func = "set_forvo_audio",
-                field_name = conf.audio_field:get_value(),
-                args = { self.popup_dict.word, self:get_language() }
-            },
+            audio = (function()
+                local audio_field = conf.audio_field:get_value()
+                local audio_driver = conf.audio_driver:get_value()
+                local language = nil
+                if audio_field and audio_driver and audio_driver ~= "none" then
+                    language = self:get_language()
+                end
+                return {
+                    func = "set_note_audio",
+                    field_name = audio_field,
+                    args = { self.popup_dict.word, language, audio_driver }
+                }
+            end)(),
             picture = {
                 func = "set_image_data",
                 field_name = conf.image_field:get_value(),

--- a/ankinote.lua
+++ b/ankinote.lua
@@ -215,7 +215,7 @@ function AnkiNote:build()
         -- all info needed to populate them is stored as a callback, which is called when a connection is available
         field_callbacks = {
             word_audio = (function()
-                local audio_field = conf.audio_field:get_value()
+                local audio_field = conf:get_word_audio_field()
                 local audio_driver = conf:get_word_audio_driver()
                 local language = nil
                 if audio_field and audio_driver and audio_driver ~= "none" then

--- a/audio_drivers.lua
+++ b/audio_drivers.lua
@@ -1,0 +1,68 @@
+local DataStorage = require("datastorage")
+local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
+
+local AudioDrivers = {
+    list = {},   -- ordered list of driver modules
+    by_id = {},  -- id -> driver module
+}
+
+function AudioDrivers:load()
+    self.list = {}
+    self.by_id = {}
+    local directory = DataStorage:getFullDataDir() .. "/plugins/anki.koplugin/audio_drivers/"
+
+    if not lfs.attributes(directory, "mode") then
+        logger.warn("AudioDrivers: directory not found:", directory)
+        return self
+    end
+
+    local files = {}
+    for file in lfs.dir(directory) do
+        if file:match("%.lua$") and file ~= "README.md" then
+            table.insert(files, file)
+        end
+    end
+    table.sort(files)
+
+    for _, file in ipairs(files) do
+        local path = directory .. file
+        local ok, driver_or_err = pcall(function()
+            return assert(loadfile(path))()
+        end)
+        if not ok then
+            logger.err(("AudioDrivers: failed to load %s: %s"):format(file, driver_or_err))
+        elseif type(driver_or_err) ~= "table" or not driver_or_err.id then
+            logger.err(("AudioDrivers: %s did not return a driver with an id"):format(file))
+        elseif type(driver_or_err.get_audio) ~= "function" then
+            logger.err(("AudioDrivers: %s missing get_audio method"):format(file))
+        elseif self.by_id[driver_or_err.id] then
+            logger.err(("AudioDrivers: duplicate driver id '%s' in %s"):format(driver_or_err.id, file))
+        else
+            table.insert(self.list, driver_or_err)
+            self.by_id[driver_or_err.id] = driver_or_err
+            logger.info(("AudioDrivers: loaded '%s' from %s"):format(driver_or_err.id, file))
+        end
+    end
+    return self
+end
+
+function AudioDrivers:get(id)
+    return self.by_id[id]
+end
+
+function AudioDrivers:choices()
+    local choices = {
+        { id = "none", name = "None", description = "Do not attach audio to the note." },
+    }
+    for _, driver in ipairs(self.list) do
+        table.insert(choices, {
+            id = driver.id,
+            name = driver.name or driver.id,
+            description = driver.description,
+        })
+    end
+    return choices
+end
+
+return AudioDrivers

--- a/audio_drivers/README.md
+++ b/audio_drivers/README.md
@@ -72,4 +72,4 @@ Supported `conf_type` values in the `settings` schema: `text`, `bool`.
 ## Built-in drivers
 
 - [`forvo.lua`](forvo.lua) — scrapes forvo.com and returns an OGG URL
-- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url`, `speaker_id`, optional `text_field` / `pitch_field` for reading + pitch accent, plus AudioQuery params like `speedScale` / `pitchScale`); returns base64 data. When `text_field` is blank, uses the default text for that audio kind (word or sentence).
+- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url`, `speaker_id`, optional `kana_field` / `pitch_field` for pitch-aware synthesis, plus AudioQuery params like `speedScale` / `pitchScale`); returns base64 data. Pitch-aware synthesis is used only when both `kana_field` and `pitch_field` values are available; otherwise the original word or sentence text is used.

--- a/audio_drivers/README.md
+++ b/audio_drivers/README.md
@@ -2,7 +2,7 @@
 
 Pluggable pronunciation audio sources for note creation.
 
-Any `.lua` file in this folder is loaded at plugin startup (except documentation). Each file must return a driver module.
+Word and sentence audio are configured independently (General Settings → Audio → Word Audio / Sentence Audio). Any `.lua` file in this folder is loaded at plugin startup (except documentation). Each file must return a driver module.
 
 ## Format
 
@@ -11,7 +11,7 @@ local MyDriver = {
     id = "my_driver",           -- unique id stored in the profile
     name = "My Driver",         -- shown in the Audio Driver menu
     description = "Optional longer description (shown on hold).",
-    -- optional: settings shown under Audio Driver Settings when this driver is selected
+    -- optional: settings shown under Driver Settings when this driver is selected
     settings = {
         {
             id = "api_key",
@@ -23,7 +23,9 @@ local MyDriver = {
 }
 
 -- ctx: { word, language, field, fields, settings }
---   fields = note field map after extensions have run (may be used as synthesis input)
+--   word     = default synthesis/lookup text (looked-up word, or context sentence for sentence audio)
+--   fields   = note field map after extensions have run (may be used as synthesis input)
+--   settings = per-driver settings for this audio kind (word or sentence)
 -- returns: ok, audio_or_nil_or_err
 function MyDriver:get_audio(ctx)
     local api_key = ctx.settings.api_key
@@ -56,18 +58,18 @@ return MyDriver
 |--------|---------|
 | `true, { url = "...", filename = "..." }` | Attach audio via remote URL |
 | `true, { data = "<base64>", filename = "..." }` | Attach audio via base64-encoded file bytes |
-| `true, nil` | Soft skip — create the note without audio |
+| `true, nil` | Soft skip — create the note without this audio |
 | `false, "message"` | Hard failure — surface the error to the user |
 
 Provide either `url` or `data` (not both). Do **not** set `fields`; the plugin attaches the configured audio field.
 
 ## Settings
 
-Driver settings are stored per profile under `audio_driver_settings[driver_id]`. Values are passed to `get_audio` as `ctx.settings`.
+Driver settings are stored per profile under `word_audio_driver_settings[driver_id]` and `sentence_audio_driver_settings[driver_id]`. Values are passed to `get_audio` as `ctx.settings`.
 
 Supported `conf_type` values in the `settings` schema: `text`, `bool`.
 
 ## Built-in drivers
 
 - [`forvo.lua`](forvo.lua) — scrapes forvo.com and returns an OGG URL
-- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url`, `speaker_id`, optional `word_field` / `pitch_field` for reading + pitch accent, plus AudioQuery params like `speedScale` / `pitchScale`); returns base64 data
+- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url`, `speaker_id`, optional `text_field` / `pitch_field` for reading + pitch accent, plus AudioQuery params like `speedScale` / `pitchScale`); returns base64 data. When `text_field` is blank, uses the default text for that audio kind (word or sentence).

--- a/audio_drivers/README.md
+++ b/audio_drivers/README.md
@@ -70,4 +70,4 @@ Supported `conf_type` values in the `settings` schema: `text`, `bool`.
 ## Built-in drivers
 
 - [`forvo.lua`](forvo.lua) — scrapes forvo.com and returns an OGG URL
-- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url`, `speaker_id`, optional `word_field` / `pitch_field` for reading + pitch accent); returns base64 data
+- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url`, `speaker_id`, optional `word_field` / `pitch_field` for reading + pitch accent, plus AudioQuery params like `speedScale` / `pitchScale`); returns base64 data

--- a/audio_drivers/README.md
+++ b/audio_drivers/README.md
@@ -1,0 +1,72 @@
+# Audio Drivers
+
+Pluggable pronunciation audio sources for note creation.
+
+Any `.lua` file in this folder is loaded at plugin startup (except documentation). Each file must return a driver module.
+
+## Format
+
+```lua
+local MyDriver = {
+    id = "my_driver",           -- unique id stored in the profile
+    name = "My Driver",         -- shown in the Audio Driver menu
+    description = "Optional longer description (shown on hold).",
+    -- optional: settings shown under Audio Driver Settings when this driver is selected
+    settings = {
+        {
+            id = "api_key",
+            name = "API Key",
+            conf_type = "text",  -- "text" (default) or "bool"
+            description = "API key for the service.",
+        },
+    },
+}
+
+-- ctx: { word, language, field, settings }
+-- returns: ok, audio_or_nil_or_err
+function MyDriver:get_audio(ctx)
+    local api_key = ctx.settings.api_key
+    -- soft skip (no audio available):
+    --   return true, nil
+    -- hard failure (abort note sync):
+    --   return false, "error message"
+
+    -- URL form (Anki downloads the file):
+    return true, {
+        url = "https://example.com/audio.ogg",
+        filename = ("my_%s.ogg"):format(ctx.word),
+    }
+
+    -- Or base64 form (Anki stores the bytes directly):
+    -- return true, {
+    --     data = "<base64-encoded audio bytes>",
+    --     filename = ("my_%s.mp3"):format(ctx.word),
+    -- }
+end
+
+return MyDriver
+```
+
+## Return values
+
+`get_audio` must return two values:
+
+| Result | Meaning |
+|--------|---------|
+| `true, { url = "...", filename = "..." }` | Attach audio via remote URL |
+| `true, { data = "<base64>", filename = "..." }` | Attach audio via base64-encoded file bytes |
+| `true, nil` | Soft skip — create the note without audio |
+| `false, "message"` | Hard failure — surface the error to the user |
+
+Provide either `url` or `data` (not both). Do **not** set `fields`; the plugin attaches the configured audio field.
+
+## Settings
+
+Driver settings are stored per profile under `audio_driver_settings[driver_id]`. Values are passed to `get_audio` as `ctx.settings`.
+
+Supported `conf_type` values in the `settings` schema: `text`, `bool`.
+
+## Built-in drivers
+
+- [`forvo.lua`](forvo.lua) — scrapes forvo.com and returns an OGG URL
+- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url` + `speaker_id` settings); returns base64 data

--- a/audio_drivers/README.md
+++ b/audio_drivers/README.md
@@ -22,7 +22,8 @@ local MyDriver = {
     },
 }
 
--- ctx: { word, language, field, settings }
+-- ctx: { word, language, field, fields, settings }
+--   fields = note field map after extensions have run (may be used as synthesis input)
 -- returns: ok, audio_or_nil_or_err
 function MyDriver:get_audio(ctx)
     local api_key = ctx.settings.api_key
@@ -69,4 +70,4 @@ Supported `conf_type` values in the `settings` schema: `text`, `bool`.
 ## Built-in drivers
 
 - [`forvo.lua`](forvo.lua) — scrapes forvo.com and returns an OGG URL
-- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url` + `speaker_id` settings); returns base64 data
+- [`voicevox.lua`](voicevox.lua) — synthesizes WAV audio via a VOICEVOX Engine (`url`, `speaker_id`, optional `word_field` / `pitch_field` for reading + pitch accent); returns base64 data

--- a/audio_drivers/forvo.lua
+++ b/audio_drivers/forvo.lua
@@ -2,14 +2,22 @@
 Copyright: Ren Tatsumoto and contributors
 License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
 
-Utils for downloading pronunciations from Forvo
+Forvo audio driver — scrapes forvo.com for a pronunciation URL.
 ]]
 
 local http = require("socket.http")
 local socket = require("socket")
 local ltn12 = require("ltn12")
 local socketutil = require("socketutil")
+local base64 = require("lua_utils/base64")
+local logger = require("logger")
 
+local Forvo = {
+    id = "forvo",
+    name = "Forvo",
+    description = "Fetch pronunciation audio from forvo.com",
+    settings = {},
+}
 
 local function GET(url)
     local sink = {}
@@ -29,47 +37,13 @@ local function GET(url)
     if code == 200 then
         return table.concat(sink)
     end
-    -- Special handling for 403 error (likely rate limit or access restriction)
     if code == 403 then
         return false, "FORVO_403"
     end
     return false, ("[%d]: %s"):format(code or -1, status or "")
 end
 
--- http://lua-users.org/wiki/BaseSixtyFour
--- character table string
-local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-local function base64e(data)
-    return ((data:gsub('.', function(x) 
-        local r,b='',x:byte()
-        for i=8,1,-1 do r=r..(b%2^i-b%2^(i-1)>0 and '1' or '0') end
-        return r;
-    end)..'0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
-        if (#x < 6) then return '' end
-        local c=0
-        for i=1,6 do c=c+(x:sub(i,i)=='1' and 2^(6-i) or 0) end
-        return b:sub(c+1,c+1)
-    end)..({ '', '==', '=' })[#data%3+1])
-end
-
-local function base64d(data)
-    data = string.gsub(data, '[^'..b..'=]', '')
-    return (data:gsub('.', function(x)
-        if (x == '=') then return '' end
-        local r,f='',(b:find(x)-1)
-        for i=6,1,-1 do r=r..(f%2^i-f%2^(i-1)>0 and '1' or '0') end
-        return r;
-    end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
-        if (#x ~= 8) then return '' end
-        local c=0
-        for i=1,8 do c=c+(x:sub(i,i)=='1' and 2^(8-i) or 0) end
-        return string.char(c)
-    end))
-end
-
-
 local function url_encode(url)
-    -- https://gist.github.com/liukun/f9ce7d6d14fa45fe9b924a3eed5c3d99
     local char_to_hex = function(c)
         return string.format("%%%02X", string.byte(c))
     end
@@ -84,6 +58,7 @@ end
 
 local function get_pronunciation_url(word, language)
     local forvo_url = ('https://forvo.com/search/%s/%s'):format(url_encode(word), language)
+    -- logger.info(("Forvo: GET %s"):format(forvo_url))
     local forvo_page, err = GET(forvo_url)
     if not forvo_page then
         return false, err
@@ -94,12 +69,36 @@ local function get_pronunciation_url(word, language)
     if play_params then
         local iter = string.gmatch(play_params, "'(.-)'")
         local formats = { mp3 = iter(), ogg = iter() }
-        word_url = string.format('https://audio00.forvo.com/%s/%s', "ogg", base64d(formats["ogg"]))
+        if formats["ogg"] then
+            word_url = string.format('https://audio00.forvo.com/%s/%s', "ogg", base64.decode(formats["ogg"]))
+        end
+    else
+        logger.warn("Forvo: page fetched but no Play(...) pronunciation found (page may be blocked or empty)")
     end
     return true, word_url
 end
 
-return {
-    get_pronunciation_url = get_pronunciation_url,
-    base64e = base64e,
-}
+-- ctx: { word, language, field, settings }
+-- returns: ok, audio_or_nil_or_err
+function Forvo:get_audio(ctx)
+    local ok, forvo_url = get_pronunciation_url(ctx.word, ctx.language)
+    if not ok then
+        if forvo_url == "FORVO_403" then
+            -- Blocked by Forvo: continue note creation without audio
+            logger.warn("Forvo returned 403 - continuing without audio")
+            return true, nil
+        end
+        return false, ("Could not connect to forvo: %s"):format(forvo_url)
+    end
+    if not forvo_url then
+        logger.warn(("Forvo: no pronunciation URL for '%s' (%s) - continuing without audio"):format(ctx.word, ctx.language))
+        return true, nil
+    end
+    logger.info(("Forvo: using audio URL %s"):format(forvo_url))
+    return true, {
+        url = forvo_url,
+        filename = string.format("forvo_%s.ogg", ctx.word),
+    }
+end
+
+return Forvo

--- a/audio_drivers/forvo.lua
+++ b/audio_drivers/forvo.lua
@@ -78,7 +78,7 @@ local function get_pronunciation_url(word, language)
     return true, word_url
 end
 
--- ctx: { word, language, field, settings }
+-- ctx: { word, language, field, fields, settings }
 -- returns: ok, audio_or_nil_or_err
 function Forvo:get_audio(ctx)
     local ok, forvo_url = get_pronunciation_url(ctx.word, ctx.language)

--- a/audio_drivers/voicevox.lua
+++ b/audio_drivers/voicevox.lua
@@ -1,9 +1,13 @@
 --[[
 VOICEVOX audio driver — synthesizes pronunciation via a VOICEVOX Engine HTTP API.
 
-API flow:
+API flow (plain text):
   1. POST /audio_query?speaker=<id>&text=<word>  → AudioQuery JSON
   2. POST /synthesis?speaker=<id>  (JSON body) → WAV bytes
+
+API flow (AquesTalk-style kana with pitch accent):
+  1. POST /accent_phrases?speaker=<id>&is_kana=true&text=<kana'> → accent phrases
+  2. Wrap phrases in an AudioQuery and POST /synthesis
 ]]
 
 local http = require("socket.http")
@@ -11,6 +15,9 @@ local socket = require("socket")
 local ltn12 = require("ltn12")
 local socketutil = require("socketutil")
 local base64 = require("lua_utils/base64")
+local u = require("lua_utils/utils")
+local util = require("util")
+local json = require("rapidjson")
 local logger = require("logger")
 
 local VoiceVox = {
@@ -30,8 +37,37 @@ local VoiceVox = {
             conf_type = "text",
             description = "VOICEVOX style/speaker id used for synthesis (e.g. 10000).",
         },
+        {
+            id = "word_field",
+            name = "Word Field",
+            conf_type = "text",
+            description = "Anki field to use as the synthesis text (e.g. KanaReading). Leave blank to use the looked-up word.",
+        },
+        {
+            id = "pitch_field",
+            name = "Pitch Accent Field",
+            conf_type = "text",
+            description = "Anki field containing the pitch accent number (e.g. VocabPitchNum with a value like [1]). Leave blank to use the looked-up word.",
+        },
     },
 }
+
+local HIRAGANA = util.splitToChars(
+    "ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをんゔ"
+)
+local KATAKANA = util.splitToChars(
+    "ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワヰヱヲンヴ"
+)
+local HIRA_TO_KATA = {}
+for i, hira in ipairs(HIRAGANA) do
+    HIRA_TO_KATA[hira] = KATAKANA[i]
+end
+
+local KANA_CHARS = u.to_set(KATAKANA)
+KANA_CHARS["ー"] = true
+
+-- Small kana that attach to the previous mora (katakana + hiragana for safety).
+local SMALL_KANA = u.to_set(util.splitToChars("ャュョァィゥェォゃゅょぁぃぅぇぉヮゎ"))
 
 local function url_encode(str)
     local char_to_hex = function(c)
@@ -84,19 +120,176 @@ end
 
 local function sanitize_filename(word)
     -- Strip path separators / control chars; keep Unicode so Japanese words stay unique.
-    local cleaned = word:gsub("[/\\%z\r\n]", "_"):gsub("%s+", "_")
+    local cleaned = word:gsub("[/\\%z\r\n]", "_"):gsub("%s+", "_"):gsub("'", "")
     if cleaned == "" then
         cleaned = "word"
     end
     return cleaned
 end
 
--- ctx: { word, language, field, settings }
+local function strip_html(text)
+    if not text or text == "" then
+        return text
+    end
+    return (text:gsub("<[^>]+>", ""))
+end
+
+local function to_katakana(text)
+    local out = {}
+    for _, ch in ipairs(util.splitToChars(text)) do
+        table.insert(out, HIRA_TO_KATA[ch] or ch)
+    end
+    return table.concat(out)
+end
+
+local function sanitize_reading(raw)
+    if not raw or raw == "" then
+        return nil
+    end
+    local text = strip_html(raw)
+    text = text:gsub("・", "")
+    text = text:gsub("%s+", "")
+    text = text:gsub("['%[%]%d]", "") -- drop any leftover pitch markup
+    if text == "" then
+        return nil
+    end
+    return to_katakana(text)
+end
+
+local function is_pure_katakana(text)
+    if not text or text == "" then
+        return false
+    end
+    for _, ch in ipairs(util.splitToChars(text)) do
+        if not KANA_CHARS[ch] then
+            return false
+        end
+    end
+    return true
+end
+
+local function extract_pitch_number(raw)
+    if not raw or raw == "" then
+        return nil
+    end
+    local text = strip_html(raw)
+    -- Prefer bracketed form like [1]; otherwise take the first digit sequence.
+    local num = text:match("%[(%d+)%]") or text:match("(%d+)")
+    if not num then
+        return nil
+    end
+    return tonumber(num)
+end
+
+local function split_morae(word)
+    local morae = {}
+    for _, ch in ipairs(util.splitToChars(word)) do
+        if SMALL_KANA[ch] and #morae > 0 then
+            table.insert(morae[#morae], ch)
+        else
+            table.insert(morae, { ch })
+        end
+    end
+    return morae
+end
+
+-- Insert an AquesTalk-style accent apostrophe after the given mora.
+-- Pitch 0 (heiban): apostrophe after the final mora.
+-- Pitch N>0: apostrophe after the Nth mora.
+local function apply_pitch_accent(katakana, pitch_num)
+    local morae = split_morae(katakana)
+    if #morae == 0 then
+        return katakana
+    end
+
+    local accent_after = pitch_num
+    if pitch_num == 0 or pitch_num > #morae then
+        accent_after = #morae
+    end
+
+    local parts = {}
+    for idx, mora in ipairs(morae) do
+        table.insert(parts, table.concat(mora))
+        if idx == accent_after then
+            table.insert(parts, "'")
+        end
+    end
+    return table.concat(parts)
+end
+
+local function resolve_synthesis_text(ctx)
+    local settings = ctx.settings or {}
+    local fields = ctx.fields or {}
+    local word_field = settings.word_field
+    local pitch_field = settings.pitch_field
+
+    -- The katakana + pitch path requires BOTH a kana reading and a pitch number.
+    -- If either is missing we fall back to the original dictionary word so VOICEVOX
+    -- can infer the reading and pitch on its own.
+    local reading = nil
+    if word_field and word_field ~= "" and fields[word_field] and fields[word_field] ~= "" then
+        reading = sanitize_reading(fields[word_field])
+        if reading and not is_pure_katakana(reading) then
+            logger.warn(("VOICEVOX: reading '%s' is not kana; falling back to dictionary word"):format(reading))
+            reading = nil
+        end
+    end
+
+    local pitch_num = nil
+    if pitch_field and pitch_field ~= "" then
+        pitch_num = extract_pitch_number(fields[pitch_field])
+    end
+
+    if reading and pitch_num ~= nil then
+        return apply_pitch_accent(reading, pitch_num), true
+    end
+
+    -- Fall back to the original dictionary word (e.g. kanji).
+    return ctx.word, false
+end
+
+local function build_audio_query_from_kana(base_url, speaker, kana_text)
+    local accent_url = ("%s/accent_phrases?speaker=%s&is_kana=true&text=%s"):format(
+        base_url, speaker, url_encode(kana_text)
+    )
+    logger.info(("VOICEVOX: requesting accent_phrases (is_kana) for '%s'"):format(kana_text))
+    local ok, phrases_or_err = http_post(accent_url, nil)
+    if not ok then
+        return false, ("VOICEVOX accent_phrases failed: %s"):format(phrases_or_err)
+    end
+
+    local phrases, decode_err = json.decode(phrases_or_err)
+    if not phrases then
+        return false, ("VOICEVOX accent_phrases returned invalid JSON: %s"):format(tostring(decode_err))
+    end
+
+    -- Standard AudioQuery defaults; accent_phrases already include length/pitch from the engine.
+    local query = {
+        accent_phrases = phrases,
+        speedScale = 1,
+        pitchScale = 0,
+        intonationScale = 1,
+        volumeScale = 1,
+        prePhonemeLength = 0.1,
+        postPhonemeLength = 0.1,
+        outputSamplingRate = 24000,
+        outputStereo = false,
+        kana = kana_text,
+    }
+    return true, json.encode(query)
+end
+
+local function build_audio_query_from_text(base_url, speaker, text)
+    local query_url = ("%s/audio_query?speaker=%s&text=%s"):format(base_url, speaker, url_encode(text))
+    logger.info(("VOICEVOX: requesting audio_query for '%s'"):format(text))
+    return http_post(query_url, nil)
+end
+
+-- ctx: { word, language, field, fields, settings }
 function VoiceVox:get_audio(ctx)
     local settings = ctx.settings or {}
     local base_url = settings.url
     local speaker_id = settings.speaker_id
-    local word = ctx.word
 
     if not base_url or base_url == "" then
         return false, "VOICEVOX Engine URL is not configured"
@@ -104,23 +297,30 @@ function VoiceVox:get_audio(ctx)
     if not speaker_id or speaker_id == "" then
         return false, "VOICEVOX Speaker Id is not configured"
     end
-    if not word or word == "" then
+
+    local text, use_kana = resolve_synthesis_text(ctx)
+    if not text or text == "" then
         return true, nil
     end
 
     base_url = normalize_base_url(base_url)
     local speaker = url_encode(tostring(speaker_id))
-    local text = url_encode(word)
 
-    local query_url = ("%s/audio_query?speaker=%s&text=%s"):format(base_url, speaker, text)
-    logger.info(("VOICEVOX: requesting audio_query for '%s' (speaker %s)"):format(word, speaker_id))
-    local ok, query_or_err = http_post(query_url, nil)
+    local ok, query_or_err
+    if use_kana then
+        ok, query_or_err = build_audio_query_from_kana(base_url, speaker, text)
+    else
+        ok, query_or_err = build_audio_query_from_text(base_url, speaker, text)
+    end
     if not ok then
+        if use_kana then
+            return false, query_or_err
+        end
         return false, ("VOICEVOX audio_query failed: %s"):format(query_or_err)
     end
 
     local synthesis_url = ("%s/synthesis?speaker=%s"):format(base_url, speaker)
-    logger.info(("VOICEVOX: requesting synthesis for '%s'"):format(word))
+    logger.info(("VOICEVOX: requesting synthesis for '%s'"):format(text))
     local synth_ok, wav_or_err = http_post(synthesis_url, query_or_err, "application/json")
     if not synth_ok then
         return false, ("VOICEVOX synthesis failed: %s"):format(wav_or_err)
@@ -129,9 +329,13 @@ function VoiceVox:get_audio(ctx)
         return false, "VOICEVOX synthesis returned empty audio"
     end
 
+    local filename_word = ctx.word
+    if not filename_word or filename_word == "" then
+        filename_word = text
+    end
     return true, {
         data = base64.encode(wav_or_err),
-        filename = string.format("voicevox_%s.wav", sanitize_filename(word)),
+        filename = string.format("voicevox_%s.wav", sanitize_filename(filename_word)),
     }
 end
 

--- a/audio_drivers/voicevox.lua
+++ b/audio_drivers/voicevox.lua
@@ -1,0 +1,138 @@
+--[[
+VOICEVOX audio driver — synthesizes pronunciation via a VOICEVOX Engine HTTP API.
+
+API flow:
+  1. POST /audio_query?speaker=<id>&text=<word>  → AudioQuery JSON
+  2. POST /synthesis?speaker=<id>  (JSON body) → WAV bytes
+]]
+
+local http = require("socket.http")
+local socket = require("socket")
+local ltn12 = require("ltn12")
+local socketutil = require("socketutil")
+local base64 = require("lua_utils/base64")
+local logger = require("logger")
+
+local VoiceVox = {
+    id = "voicevox",
+    name = "VOICEVOX",
+    description = "Synthesize pronunciation audio via a VOICEVOX Engine server.",
+    settings = {
+        {
+            id = "url",
+            name = "Engine URL",
+            conf_type = "text",
+            description = "Base URL of the VOICEVOX Engine (e.g. http://192.168.0.1:50121).",
+        },
+        {
+            id = "speaker_id",
+            name = "Speaker Id",
+            conf_type = "text",
+            description = "VOICEVOX style/speaker id used for synthesis (e.g. 10000).",
+        },
+    },
+}
+
+local function url_encode(str)
+    local char_to_hex = function(c)
+        return string.format("%%%02X", string.byte(c))
+    end
+    if str == nil then
+        return
+    end
+    str = str:gsub("\n", "\r\n")
+    str = str:gsub("([^%w _%%%-%.~])", char_to_hex)
+    str = str:gsub(" ", "+")
+    return str
+end
+
+local function normalize_base_url(url)
+    return (url:gsub("/+$", ""))
+end
+
+local function http_post(url, body, content_type)
+    local sink = {}
+    socketutil:set_timeout(socketutil.LARGE_BLOCK_TIMEOUT, socketutil.LARGE_TOTAL_TIMEOUT)
+    local headers = {
+        ["Accept"] = "*/*",
+    }
+    local source = nil
+    if body then
+        headers["Content-Type"] = content_type or "application/json"
+        headers["Content-Length"] = #body
+        source = ltn12.source.string(body)
+    else
+        headers["Content-Length"] = 0
+    end
+    local request = {
+        url = url,
+        method = "POST",
+        headers = headers,
+        sink = ltn12.sink.table(sink),
+        source = source,
+    }
+    local code, _, status = socket.skip(1, http.request(request))
+    socketutil:reset_timeout()
+    if code == 200 then
+        return true, table.concat(sink)
+    end
+    if type(code) == "string" then
+        return false, code
+    end
+    return false, ("[%s]: %s"):format(tostring(code or -1), status or "")
+end
+
+local function sanitize_filename(word)
+    -- Strip path separators / control chars; keep Unicode so Japanese words stay unique.
+    local cleaned = word:gsub("[/\\%z\r\n]", "_"):gsub("%s+", "_")
+    if cleaned == "" then
+        cleaned = "word"
+    end
+    return cleaned
+end
+
+-- ctx: { word, language, field, settings }
+function VoiceVox:get_audio(ctx)
+    local settings = ctx.settings or {}
+    local base_url = settings.url
+    local speaker_id = settings.speaker_id
+    local word = ctx.word
+
+    if not base_url or base_url == "" then
+        return false, "VOICEVOX Engine URL is not configured"
+    end
+    if not speaker_id or speaker_id == "" then
+        return false, "VOICEVOX Speaker Id is not configured"
+    end
+    if not word or word == "" then
+        return true, nil
+    end
+
+    base_url = normalize_base_url(base_url)
+    local speaker = url_encode(tostring(speaker_id))
+    local text = url_encode(word)
+
+    local query_url = ("%s/audio_query?speaker=%s&text=%s"):format(base_url, speaker, text)
+    logger.info(("VOICEVOX: requesting audio_query for '%s' (speaker %s)"):format(word, speaker_id))
+    local ok, query_or_err = http_post(query_url, nil)
+    if not ok then
+        return false, ("VOICEVOX audio_query failed: %s"):format(query_or_err)
+    end
+
+    local synthesis_url = ("%s/synthesis?speaker=%s"):format(base_url, speaker)
+    logger.info(("VOICEVOX: requesting synthesis for '%s'"):format(word))
+    local synth_ok, wav_or_err = http_post(synthesis_url, query_or_err, "application/json")
+    if not synth_ok then
+        return false, ("VOICEVOX synthesis failed: %s"):format(wav_or_err)
+    end
+    if not wav_or_err or #wav_or_err == 0 then
+        return false, "VOICEVOX synthesis returned empty audio"
+    end
+
+    return true, {
+        data = base64.encode(wav_or_err),
+        filename = string.format("voicevox_%s.wav", sanitize_filename(word)),
+    }
+end
+
+return VoiceVox

--- a/audio_drivers/voicevox.lua
+++ b/audio_drivers/voicevox.lua
@@ -49,6 +49,48 @@ local VoiceVox = {
             conf_type = "text",
             description = "Anki field containing the pitch accent number (e.g. VocabPitchNum with a value like [1]). Leave blank to use the looked-up word.",
         },
+        {
+            id = "speedScale",
+            name = "Speed (速度)",
+            conf_type = "text",
+            default = "1.0",
+            description = "Speaking speed.",
+        },
+        {
+            id = "pitchScale",
+            name = "Pitch (音高)",
+            conf_type = "text",
+            default = "0.0",
+            description = "Overall pitch.",
+        },
+        {
+            id = "intonationScale",
+            name = "Intonation (抑揚)",
+            conf_type = "text",
+            default = "1.0",
+            description = "Intonation strength.",
+        },
+        {
+            id = "volumeScale",
+            name = "Volume (音量)",
+            conf_type = "text",
+            default = "1.0",
+            description = "Volume.",
+        },
+        {
+            id = "prePhonemeLength",
+            name = "Pre-silence (開始無音)",
+            conf_type = "text",
+            default = "0.1",
+            description = "Silence before speech (seconds).",
+        },
+        {
+            id = "postPhonemeLength",
+            name = "Post-silence (終了無音)",
+            conf_type = "text",
+            default = "0.1",
+            description = "Silence after speech (seconds).",
+        },
     },
 }
 
@@ -248,6 +290,53 @@ local function resolve_synthesis_text(ctx)
     return ctx.word, false
 end
 
+-- Defaults for user-configurable AudioQuery fields.
+local AUDIO_QUERY_DEFAULTS = {
+    speedScale = 1.0,
+    pitchScale = 0.0,
+    intonationScale = 1.0,
+    volumeScale = 1.0,
+    prePhonemeLength = 0.1,
+    postPhonemeLength = 0.1,
+}
+
+local function resolve_number_setting(settings, id, default)
+    local raw = settings[id]
+    if raw == nil or raw == "" then
+        return default
+    end
+    local num = tonumber(raw)
+    if not num then
+        logger.warn(("VOICEVOX: invalid %s '%s'; using default %s"):format(id, tostring(raw), tostring(default)))
+        return default
+    end
+    return num
+end
+
+local function resolve_audio_query_params(settings)
+    settings = settings or {}
+    return {
+        speedScale = resolve_number_setting(settings, "speedScale", AUDIO_QUERY_DEFAULTS.speedScale),
+        pitchScale = resolve_number_setting(settings, "pitchScale", AUDIO_QUERY_DEFAULTS.pitchScale),
+        intonationScale = resolve_number_setting(settings, "intonationScale", AUDIO_QUERY_DEFAULTS.intonationScale),
+        volumeScale = resolve_number_setting(settings, "volumeScale", AUDIO_QUERY_DEFAULTS.volumeScale),
+        prePhonemeLength = resolve_number_setting(settings, "prePhonemeLength", AUDIO_QUERY_DEFAULTS.prePhonemeLength),
+        postPhonemeLength = resolve_number_setting(settings, "postPhonemeLength", AUDIO_QUERY_DEFAULTS.postPhonemeLength),
+    }
+end
+
+-- Overlay user synthesis params onto an AudioQuery JSON body.
+local function apply_audio_query_params(query_json, params)
+    local query, decode_err = json.decode(query_json)
+    if not query then
+        return false, ("VOICEVOX audio_query returned invalid JSON: %s"):format(tostring(decode_err))
+    end
+    for key, value in pairs(params) do
+        query[key] = value
+    end
+    return true, json.encode(query)
+end
+
 local function build_audio_query_from_kana(base_url, speaker, kana_text)
     local accent_url = ("%s/accent_phrases?speaker=%s&is_kana=true&text=%s"):format(
         base_url, speaker, url_encode(kana_text)
@@ -263,15 +352,17 @@ local function build_audio_query_from_kana(base_url, speaker, kana_text)
         return false, ("VOICEVOX accent_phrases returned invalid JSON: %s"):format(tostring(decode_err))
     end
 
-    -- Standard AudioQuery defaults; accent_phrases already include length/pitch from the engine.
+    -- /accent_phrases returns phrases only; we wrap them in an AudioQuery.
+    -- outputSamplingRate / outputStereo are required by the /synthesis schema (no omit-default),
+    -- so use the same values /audio_query would fill in. Configurable params are overlaid later.
     local query = {
         accent_phrases = phrases,
-        speedScale = 1,
-        pitchScale = 0,
-        intonationScale = 1,
-        volumeScale = 1,
-        prePhonemeLength = 0.1,
-        postPhonemeLength = 0.1,
+        speedScale = AUDIO_QUERY_DEFAULTS.speedScale,
+        pitchScale = AUDIO_QUERY_DEFAULTS.pitchScale,
+        intonationScale = AUDIO_QUERY_DEFAULTS.intonationScale,
+        volumeScale = AUDIO_QUERY_DEFAULTS.volumeScale,
+        prePhonemeLength = AUDIO_QUERY_DEFAULTS.prePhonemeLength,
+        postPhonemeLength = AUDIO_QUERY_DEFAULTS.postPhonemeLength,
         outputSamplingRate = 24000,
         outputStereo = false,
         kana = kana_text,
@@ -317,6 +408,12 @@ function VoiceVox:get_audio(ctx)
             return false, query_or_err
         end
         return false, ("VOICEVOX audio_query failed: %s"):format(query_or_err)
+    end
+
+    local params = resolve_audio_query_params(settings)
+    ok, query_or_err = apply_audio_query_params(query_or_err, params)
+    if not ok then
+        return false, query_or_err
     end
 
     local synthesis_url = ("%s/synthesis?speaker=%s"):format(base_url, speaker)

--- a/audio_drivers/voicevox.lua
+++ b/audio_drivers/voicevox.lua
@@ -38,10 +38,10 @@ local VoiceVox = {
             description = "VOICEVOX style/speaker id used for synthesis (e.g. 10000).",
         },
         {
-            id = "word_field",
-            name = "Word Field",
+            id = "text_field",
+            name = "Text Field",
             conf_type = "text",
-            description = "Anki field to use as the synthesis text (e.g. KanaReading). Leave blank to use the looked-up word.",
+            description = "Anki field to use as the synthesis text (e.g. KanaReading). Leave blank to use the default text (looked-up word for word audio, context sentence for sentence audio).",
         },
         {
             id = "pitch_field",
@@ -262,17 +262,18 @@ end
 local function resolve_synthesis_text(ctx)
     local settings = ctx.settings or {}
     local fields = ctx.fields or {}
-    local word_field = settings.word_field
+    -- Prefer text_field; fall back to legacy word_field from older profiles.
+    local text_field = settings.text_field or settings.word_field
     local pitch_field = settings.pitch_field
 
     -- The katakana + pitch path requires BOTH a kana reading and a pitch number.
-    -- If either is missing we fall back to the original dictionary word so VOICEVOX
+    -- If either is missing we fall back to the default text (ctx.word) so VOICEVOX
     -- can infer the reading and pitch on its own.
     local reading = nil
-    if word_field and word_field ~= "" and fields[word_field] and fields[word_field] ~= "" then
-        reading = sanitize_reading(fields[word_field])
+    if text_field and text_field ~= "" and fields[text_field] and fields[text_field] ~= "" then
+        reading = sanitize_reading(fields[text_field])
         if reading and not is_pure_katakana(reading) then
-            logger.warn(("VOICEVOX: reading '%s' is not kana; falling back to dictionary word"):format(reading))
+            logger.warn(("VOICEVOX: reading '%s' is not kana; falling back to default text"):format(reading))
             reading = nil
         end
     end
@@ -286,8 +287,8 @@ local function resolve_synthesis_text(ctx)
         return apply_pitch_accent(reading, pitch_num), true
     end
 
-    -- Fall back to the original dictionary word (e.g. kanji).
-    return ctx.word, false
+    -- Fall back to the default text passed by the caller (word or sentence).
+    return strip_html(ctx.word), false
 end
 
 -- Defaults for user-configurable AudioQuery fields.

--- a/audio_drivers/voicevox.lua
+++ b/audio_drivers/voicevox.lua
@@ -38,16 +38,16 @@ local VoiceVox = {
             description = "VOICEVOX style/speaker id used for synthesis (e.g. 10000).",
         },
         {
-            id = "text_field",
-            name = "Text Field",
+            id = "kana_field",
+            name = "Kana Field",
             conf_type = "text",
-            description = "Anki field to use as the synthesis text (e.g. KanaReading). Leave blank to use the default text (looked-up word for word audio, context sentence for sentence audio).",
+            description = "Anki field with the kana reading (e.g. KanaReading). Used together with Pitch Accent Field for pitch-aware synthesis. If either field is missing or empty, the original word or sentence text is used instead.",
         },
         {
             id = "pitch_field",
             name = "Pitch Accent Field",
             conf_type = "text",
-            description = "Anki field containing the pitch accent number (e.g. VocabPitchNum with a value like [1]). Leave blank to use the looked-up word.",
+            description = "Anki field with the pitch accent number (e.g. VocabPitchNum with a value like [1]). Used together with Kana Field for pitch-aware synthesis. If either field is missing or empty, the original word or sentence text is used instead.",
         },
         {
             id = "speedScale",
@@ -262,18 +262,17 @@ end
 local function resolve_synthesis_text(ctx)
     local settings = ctx.settings or {}
     local fields = ctx.fields or {}
-    -- Prefer text_field; fall back to legacy word_field from older profiles.
-    local text_field = settings.text_field or settings.word_field
+    -- Prefer kana_field; accept legacy text_field / word_field from older profiles.
+    local kana_field = settings.kana_field or settings.text_field or settings.word_field
     local pitch_field = settings.pitch_field
 
-    -- The katakana + pitch path requires BOTH a kana reading and a pitch number.
-    -- If either is missing we fall back to the default text (ctx.word) so VOICEVOX
-    -- can infer the reading and pitch on its own.
+    -- Pitch-aware path requires BOTH a pure-kana reading and a pitch number.
+    -- If either is missing, fall back to the original word or sentence text.
     local reading = nil
-    if text_field and text_field ~= "" and fields[text_field] and fields[text_field] ~= "" then
-        reading = sanitize_reading(fields[text_field])
+    if kana_field and kana_field ~= "" and fields[kana_field] and fields[kana_field] ~= "" then
+        reading = sanitize_reading(fields[kana_field])
         if reading and not is_pure_katakana(reading) then
-            logger.warn(("VOICEVOX: reading '%s' is not kana; falling back to default text"):format(reading))
+            logger.warn(("VOICEVOX: kana_field value '%s' is not kana; falling back to original text"):format(reading))
             reading = nil
         end
     end
@@ -287,7 +286,6 @@ local function resolve_synthesis_text(ctx)
         return apply_pitch_accent(reading, pitch_num), true
     end
 
-    -- Fall back to the default text passed by the caller (word or sentence).
     return strip_html(ctx.word), false
 end
 

--- a/lua_utils/base64.lua
+++ b/lua_utils/base64.lua
@@ -1,0 +1,35 @@
+-- http://lua-users.org/wiki/BaseSixtyFour
+local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+local function encode(data)
+    return ((data:gsub('.', function(x)
+        local r, byte = '', x:byte()
+        for i = 8, 1, -1 do r = r .. (byte % 2 ^ i - byte % 2 ^ (i - 1) > 0 and '1' or '0') end
+        return r
+    end) .. '0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if (#x < 6) then return '' end
+        local c = 0
+        for i = 1, 6 do c = c + (x:sub(i, i) == '1' and 2 ^ (6 - i) or 0) end
+        return b:sub(c + 1, c + 1)
+    end) .. ({ '', '==', '=' })[#data % 3 + 1])
+end
+
+local function decode(data)
+    data = string.gsub(data, '[^' .. b .. '=]', '')
+    return (data:gsub('.', function(x)
+        if (x == '=') then return '' end
+        local r, f = '', (b:find(x) - 1)
+        for i = 6, 1, -1 do r = r .. (f % 2 ^ i - f % 2 ^ (i - 1) > 0 and '1' or '0') end
+        return r
+    end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
+        if (#x ~= 8) then return '' end
+        local c = 0
+        for i = 1, 8 do c = c + (x:sub(i, i) == '1' and 2 ^ (8 - i) or 0) end
+        return string.char(c)
+    end))
+end
+
+return {
+    encode = encode,
+    decode = decode,
+}

--- a/main.lua
+++ b/main.lua
@@ -55,11 +55,71 @@ function AnkiWidget:show_profiles_widget(opts)
     UIManager:show(self.profile_change_widget)
 end
 
+function AnkiWidget:set_add_to_anki_button_text(text, opts)
+    opts = opts or {}
+    local popup_dict = self.popup_dict
+    if not popup_dict or not popup_dict.button_table then
+        return
+    end
+    local btn = popup_dict.button_table:getButtonById("add_to_anki")
+    if not btn then
+        return
+    end
+    btn:setText(text, btn.width)
+    if opts.enable == true then
+        btn:enable()
+    elseif opts.enable == false then
+        btn:disable()
+    end
+    btn:refresh()
+    if opts.repaint then
+        UIManager:forceRePaint()
+    end
+end
+
+function AnkiWidget:add_current_note()
+    self:set_add_to_anki_button_text(_("Adding..."), { enable = false, repaint = true })
+    local result = AnkiConnect:add_note(self.current_note)
+    if result == true then
+        self:set_add_to_anki_button_text(_("Added to Anki"), { enable = true, repaint = true })
+    else
+        -- Failure (and offline store): restore default label; errors already show a popup.
+        self:set_add_to_anki_button_text(_("Add to Anki"), { enable = true, repaint = true })
+    end
+    return result
+end
+
+function AnkiWidget:make_add_to_anki_button(popup_dict)
+    return {
+        id = "add_to_anki",
+        text = _("Add to Anki"),
+        font_bold = true,
+        callback = function()
+            self:set_profile(function()
+                self:check_conn(function()
+                    self.popup_dict = popup_dict
+                    self.current_note = AnkiNote:new(popup_dict)
+                    self:add_current_note()
+                end)
+            end)
+        end,
+        hold_callback = function()
+            self:set_profile(function()
+                self:check_conn(function()
+                    self.popup_dict = popup_dict
+                    self.current_note = AnkiNote:new(popup_dict)
+                    self:show_config_widget()
+                end)
+            end)
+        end,
+    }
+end
+
 function AnkiWidget:show_config_widget()
     local with_custom_tags_cb = function()
         self.current_note:add_tags(Configuration.custom_tags:get_value())
-        AnkiConnect:add_note(self.current_note)
         self.config_widget:onClose()
+        self:add_current_note()
     end
     self.config_widget = ButtonDialog:new {
         buttons = {
@@ -99,9 +159,9 @@ function AnkiWidget:show_custom_context_widget()
     local function on_save_cb()
         local m = self.context_menu
         self.current_note:set_custom_context(m.prev_s_cnt, m.prev_c_cnt, m.next_s_cnt, m.next_c_cnt)
-        AnkiConnect:add_note(self.current_note)
         self.context_menu:onClose()
         self.config_widget:onClose()
+        self:add_current_note()
     end
     self.context_menu = CustomContextMenu:new{
         note = self.current_note, -- to extract context out of
@@ -403,25 +463,7 @@ function AnkiWidget:handle_events()
         -- Insert new button in the popup dictionary to allow adding anki cards
         -- TODO disable button if lookup was not contextual
         DictQuickLookup.tweak_buttons_func = function(popup_dict, buttons)
-            self.add_to_anki_btn = {
-                id = "add_to_anki",
-                text = _("Add to Anki"),
-                font_bold = true,
-                callback = function()
-                    self:set_profile(function()
-                        self:check_conn(function()
-                            self.current_note = AnkiNote:new(popup_dict)
-                            AnkiConnect:add_note(self.current_note)
-                        end)
-                    end)
-                end,
-                hold_callback = function()
-                    self:set_profile(function()
-                        self.current_note = AnkiNote:new(popup_dict)
-                        self:show_config_widget()
-                    end)
-                end,
-            }
+            self.add_to_anki_btn = self:make_add_to_anki_button(popup_dict)
             table.insert(buttons, 1, { self.add_to_anki_btn })
         end
         local filepath = doc_settings.data.doc_path
@@ -443,27 +485,7 @@ function AnkiWidget:onDictButtonsReady(popup_dict, buttons)
     if self.ui.vocabbuilder and UIManager:isWidgetShown(self.ui.vocabbuilder.widget) then
         return
     end
-    self.add_to_anki_btn = {
-        id = "add_to_anki",
-        text = _("Add to Anki"),
-        font_bold = true,
-        callback = function()
-            self:set_profile(function()
-                self:check_conn(function()
-                    self.current_note = AnkiNote:new(popup_dict)
-                    AnkiConnect:add_note(self.current_note)
-                end)
-            end)
-        end,
-        hold_callback = function()
-            self:set_profile(function()
-                self:check_conn(function()
-                    self.current_note = AnkiNote:new(popup_dict)
-                    self:show_config_widget()
-                end)
-            end)
-        end,
-    }
+    self.add_to_anki_btn = self:make_add_to_anki_button(popup_dict)
     table.insert(buttons, 1, { self.add_to_anki_btn })
 end
 

--- a/main.lua
+++ b/main.lua
@@ -18,6 +18,7 @@ local _ = require("gettext")
 local lfs = require("libs/libkoreader-lfs")
 local AnkiConnect = require("ankiconnect")
 local AnkiNote = require("ankinote")
+local AudioDrivers = require("audio_drivers")
 local Configuration = require("anki_configuration")
 
 local AnkiWidget = WidgetContainer:extend {
@@ -208,6 +209,7 @@ end
 function AnkiWidget:buildSettings()
     local builder = MenuBuilder:new{
         extensions = self.extensions,
+        audio_drivers = AudioDrivers,
         ui = self.ui
     }
     local function make_new_profile(start_data)
@@ -304,6 +306,7 @@ end
 -- This function is called automatically for all tables extending from Widget
 function AnkiWidget:init()
     self:load_extensions()
+    AudioDrivers:load()
     -- allow propagating events to ankiconnect, we handle wifi related stuff in there
     table.insert(self, AnkiConnect)
     AnkiConnect:load_notes()

--- a/menubuilder.lua
+++ b/menubuilder.lua
@@ -80,8 +80,25 @@ local menu_entries = {
      {
         id = "audio_field",
         group = note_settings,
-        name = "Forvo Audio Field",
-        description = "Anki field to store Forvo audio in.",
+        name = "Audio Field",
+        description = "Anki field to store pronunciation audio in.",
+    },
+     {
+        id = "audio_driver",
+        group = note_settings,
+        name = "Audio Driver",
+        description = "Source used to fetch pronunciation audio. Select None to skip audio.",
+        conf_type = "choice",
+        choices = function(self)
+            return self.audio_drivers:choices()
+        end,
+    },
+     {
+        id = "audio_driver_settings",
+        group = note_settings,
+        name = "Audio Driver Settings",
+        description = "Settings specific to the selected audio driver.",
+        conf_type = "audio_driver_settings",
     },
      {
         id = "img_field",
@@ -233,6 +250,108 @@ function MenuConfigOpt:build_checklist()
     return menu_items
 end
 
+function MenuConfigOpt:build_choice()
+    local menu_items = {}
+    local choices = self.choices
+    if type(choices) == "function" then
+        choices = choices(self)
+    end
+    for _, choice in ipairs(choices or {}) do
+        local item = {
+            text = choice.name or choice.id,
+            checked_func = function() return self:get_value() == choice.id end,
+            callback = function()
+                self:update_value(choice.id)
+            end,
+        }
+        if choice.description then
+            item.hold_callback = function()
+                UIManager:show(InfoMessage:new { text = choice.description, timeout = nil })
+            end
+        end
+        table.insert(menu_items, item)
+    end
+    return menu_items
+end
+
+function MenuConfigOpt:build_audio_driver_settings()
+    local driver_id_setting = config.audio_driver:copy {
+        active_luasettings = self.active_luasettings,
+        default_luasettings = self.default_luasettings,
+    }
+    local driver_id = driver_id_setting:get_value()
+    if not driver_id or driver_id == "none" then
+        return { { text = "No audio driver selected", enabled = false } }
+    end
+    local driver = self.audio_drivers:get(driver_id)
+    if not driver or not driver.settings or #driver.settings == 0 then
+        return { { text = "This driver has no settings", enabled = false } }
+    end
+
+    local menu_items = {}
+    for _, setting_def in ipairs(driver.settings) do
+        local conf_type = setting_def.conf_type or "text"
+        if conf_type == "bool" then
+            table.insert(menu_items, {
+                text = setting_def.name or setting_def.id,
+                keep_menu_open = true,
+                checked_func = function()
+                    local all = self:get_value_nodefault() or {}
+                    local driver_settings = all[driver_id] or {}
+                    local val = driver_settings[setting_def.id]
+                    if val == nil then return setting_def.default == true end
+                    return val == true
+                end,
+                callback = function()
+                    local all = util.tableDeepCopy(self:get_value_nodefault() or {})
+                    all[driver_id] = all[driver_id] or {}
+                    local current = all[driver_id][setting_def.id]
+                    if current == nil then current = setting_def.default end
+                    all[driver_id][setting_def.id] = not current
+                    self:update_value(all)
+                end,
+                hold_callback = setting_def.description and function()
+                    UIManager:show(InfoMessage:new { text = setting_def.description, timeout = nil })
+                end or nil,
+            })
+        else
+            table.insert(menu_items, {
+                text = setting_def.name or setting_def.id,
+                keep_menu_open = true,
+                callback = function()
+                    local all = util.tableDeepCopy(self:get_value_nodefault() or {})
+                    all[driver_id] = all[driver_id] or {}
+                    local current = all[driver_id][setting_def.id]
+                    if current == nil then current = setting_def.default or "" end
+                    local cb = function(dialog)
+                        local text = dialog:getInputText()
+                        if text == "" then
+                            all[driver_id][setting_def.id] = nil
+                        else
+                            all[driver_id][setting_def.id] = text
+                        end
+                        self:update_value(all)
+                        UIManager:close(dialog)
+                    end
+                    local input_dialog = MenuBuilder.build_single_dialog(
+                        setting_def.name or setting_def.id,
+                        tostring(current),
+                        setting_def.name or setting_def.id,
+                        setting_def.description,
+                        cb
+                    )
+                    UIManager:show(input_dialog)
+                    input_dialog:onShowKeyboard()
+                end,
+                hold_callback = setting_def.description and function()
+                    UIManager:show(InfoMessage:new { text = setting_def.description, timeout = nil })
+                end or nil,
+            })
+        end
+    end
+    return menu_items
+end
+
 function MenuConfigOpt:build_map_dialog()
     local function is_enabled(k)
         return (self:get_value_nodefault() or {})[k] ~= nil
@@ -296,6 +415,7 @@ end
 function MenuBuilder:new(opts)
     self.ui = opts.ui -- needed to get the enabled dictionaries
     self.extensions = opts.extensions
+    self.audio_drivers = opts.audio_drivers
     return self
 end
 
@@ -358,6 +478,10 @@ function MenuBuilder:convert_opt(opt)
         sub_item_entry['callback'] = function() return opt:build_list_dialog() end
     elseif opt.conf_type == "checklist" then
         sub_item_entry['sub_item_table'] = opt:build_checklist()
+    elseif opt.conf_type == "choice" then
+        sub_item_entry['sub_item_table_func'] = function() return opt:build_choice() end
+    elseif opt.conf_type == "audio_driver_settings" then
+        sub_item_entry['sub_item_table_func'] = function() return opt:build_audio_driver_settings() end
     elseif opt.conf_type == "map" then
         sub_item_entry['sub_item_table'] = opt:build_map_dialog()
     else -- TODO multitable

--- a/menubuilder.lua
+++ b/menubuilder.lua
@@ -78,10 +78,10 @@ local menu_entries = {
         description = "Anki field to store metadata about the current book.",
     },
      {
-        id = "audio_field",
+        id = "word_audio_field",
         group = note_settings,
         name = "Word Audio Field",
-        description = "Anki field to store word pronunciation audio in.",
+        description = "Anki field to store word pronunciation audio in. Falls back to legacy audio_field if unset.",
     },
      {
         id = "sentence_audio_field",

--- a/menubuilder.lua
+++ b/menubuilder.lua
@@ -80,25 +80,54 @@ local menu_entries = {
      {
         id = "audio_field",
         group = note_settings,
-        name = "Audio Field",
-        description = "Anki field to store pronunciation audio in.",
+        name = "Word Audio Field",
+        description = "Anki field to store word pronunciation audio in.",
     },
      {
-        id = "audio_driver",
+        id = "sentence_audio_field",
         group = note_settings,
+        name = "Sentence Audio Field",
+        description = "Anki field to store sentence pronunciation audio in.",
+    },
+     {
+        id = "word_audio_driver",
+        group = general_settings,
+        submenu = { "Audio", "Word Audio" },
         name = "Audio Driver",
-        description = "Source used to fetch pronunciation audio. Select None to skip audio.",
+        description = "Source used to fetch word pronunciation audio. Select None to skip.",
         conf_type = "choice",
         choices = function(self)
             return self.audio_drivers:choices()
         end,
     },
      {
-        id = "audio_driver_settings",
-        group = note_settings,
-        name = "Audio Driver Settings",
-        description = "Settings specific to the selected audio driver.",
+        id = "word_audio_driver_settings",
+        group = general_settings,
+        submenu = { "Audio", "Word Audio" },
+        name = "Driver Settings",
+        description = "Settings specific to the selected word audio driver.",
         conf_type = "audio_driver_settings",
+        driver_setting_id = "word_audio_driver",
+    },
+     {
+        id = "sentence_audio_driver",
+        group = general_settings,
+        submenu = { "Audio", "Sentence Audio" },
+        name = "Audio Driver",
+        description = "Source used to fetch sentence pronunciation audio. Select None to skip.",
+        conf_type = "choice",
+        choices = function(self)
+            return self.audio_drivers:choices()
+        end,
+    },
+     {
+        id = "sentence_audio_driver_settings",
+        group = general_settings,
+        submenu = { "Audio", "Sentence Audio" },
+        name = "Driver Settings",
+        description = "Settings specific to the selected sentence audio driver.",
+        conf_type = "audio_driver_settings",
+        driver_setting_id = "sentence_audio_driver",
     },
      {
         id = "img_field",
@@ -256,10 +285,16 @@ function MenuConfigOpt:build_choice()
     if type(choices) == "function" then
         choices = choices(self)
     end
+    local function current_value()
+        if self.value_func then
+            return self.value_func(self)
+        end
+        return self:get_value()
+    end
     for _, choice in ipairs(choices or {}) do
         local item = {
             text = choice.name or choice.id,
-            checked_func = function() return self:get_value() == choice.id end,
+            checked_func = function() return current_value() == choice.id end,
             callback = function()
                 self:update_value(choice.id)
             end,
@@ -275,7 +310,8 @@ function MenuConfigOpt:build_choice()
 end
 
 function MenuConfigOpt:build_audio_driver_settings()
-    local driver_id_setting = config.audio_driver:copy {
+    local driver_setting_id = self.driver_setting_id or "word_audio_driver"
+    local driver_id_setting = config[driver_setting_id]:copy {
         active_luasettings = self.active_luasettings,
         default_luasettings = self.default_luasettings,
     }
@@ -288,6 +324,10 @@ function MenuConfigOpt:build_audio_driver_settings()
         return { { text = "This driver has no settings", enabled = false } }
     end
 
+    local function current_all_settings()
+        return util.tableDeepCopy(self:get_value_nodefault() or {})
+    end
+
     local menu_items = {}
     for _, setting_def in ipairs(driver.settings) do
         local conf_type = setting_def.conf_type or "text"
@@ -296,14 +336,14 @@ function MenuConfigOpt:build_audio_driver_settings()
                 text = setting_def.name or setting_def.id,
                 keep_menu_open = true,
                 checked_func = function()
-                    local all = self:get_value_nodefault() or {}
+                    local all = current_all_settings()
                     local driver_settings = all[driver_id] or {}
                     local val = driver_settings[setting_def.id]
                     if val == nil then return setting_def.default == true end
                     return val == true
                 end,
                 callback = function()
-                    local all = util.tableDeepCopy(self:get_value_nodefault() or {})
+                    local all = current_all_settings()
                     all[driver_id] = all[driver_id] or {}
                     local current = all[driver_id][setting_def.id]
                     if current == nil then current = setting_def.default end
@@ -319,7 +359,7 @@ function MenuConfigOpt:build_audio_driver_settings()
                 text = setting_def.name or setting_def.id,
                 keep_menu_open = true,
                 callback = function()
-                    local all = util.tableDeepCopy(self:get_value_nodefault() or {})
+                    local all = current_all_settings()
                     all[driver_id] = all[driver_id] or {}
                     local current = all[driver_id][setting_def.id]
                     if current == nil then current = setting_def.default or "" end
@@ -350,6 +390,31 @@ function MenuConfigOpt:build_audio_driver_settings()
         end
     end
     return menu_items
+end
+
+--- Insert a menu entry under an optional nested submenu path within items.
+local function insert_with_submenu(items, submenu_path, entry)
+    if not submenu_path or #submenu_path == 0 then
+        table.insert(items, entry)
+        return
+    end
+    local name = submenu_path[1]
+    local child = nil
+    for _, existing in ipairs(items) do
+        if existing.text == name and existing.sub_item_table then
+            child = existing
+            break
+        end
+    end
+    if not child then
+        child = { text = name, keep_menu_open = true, sub_item_table = {} }
+        table.insert(items, child)
+    end
+    local rest = {}
+    for i = 2, #submenu_path do
+        table.insert(rest, submenu_path[i])
+    end
+    insert_with_submenu(child.sub_item_table, rest, entry)
 end
 
 function MenuConfigOpt:build_map_dialog()
@@ -442,7 +507,7 @@ function MenuBuilder:build()
         for group, group_entries in pairs(List:new(menu_options):group_by(grouping_func):get()) do
             local menu_group = {}
             for _,opt in ipairs(group_entries) do
-                table.insert(menu_group, self:convert_opt(opt))
+                insert_with_submenu(menu_group, opt.submenu, self:convert_opt(opt))
             end
             table.insert(sub_item_table, { text = group, sub_item_table = menu_group })
         end

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -70,6 +70,13 @@ local Config = {
     --         -- Optional: synthesize from a kana reading field + pitch accent position instead of the kanji
     --         word_field = "KanaReading",
     --         pitch_field = "VocabPitchNum",
+    --         -- Optional AudioQuery params (defaults shown)
+    --         -- speedScale = "1.0",
+    --         -- pitchScale = "0.0",
+    --         -- intonationScale = "1.0",
+    --         -- volumeScale = "1.0",
+    --         -- prePhonemeLength = "0.1",
+    --         -- postPhonemeLength = "0.1",
     --     },
     -- },
     audio_driver_settings = {},

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -54,9 +54,22 @@ local Config = {
     -- This metadata is parsed from the EPUB's metadata, or from the filename
     meta_field = "Notes",
 
-    -- The plugin can query Forvo for audio of the word you just looked up.
-    -- The field name where the audio will be sent to.
+    -- The field name where pronunciation audio will be sent to (leave blank to disable audio lookup).
     audio_field = "VocabAudio",
+
+    -- Which audio driver to use when audio_field is set.
+    -- Built-in: "forvo", "voicevox". Use "none" to skip audio even if audio_field is set.
+    -- See audio_drivers/README.md for adding custom drivers.
+    audio_driver = "forvo",
+
+    -- Per-driver settings, keyed by driver id. Example:
+    -- audio_driver_settings = {
+    --     voicevox = {
+    --         url = "http://192.168.0.1.lan:50121",
+    --         speaker_id = "10000",
+    --     },
+    -- },
+    audio_driver_settings = {},
 
     -- list of extensions which should be enabled, by default they are all off
     -- an extension is turned on by listing its filename in the table below

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,6 +1,6 @@
 # Profiles
 
-The plugin is configured via profiles. Each profile is a `.lua` file with a single table containing all user configurable settings. 
+The plugin is configured via profiles. Each profile is a `.lua` file with a single table containing all user configurable settings.
 
 To use the plugin, copy the code snippet below and save it in a new file, this file can be named whatever you want, as long as it has a `.lua` suffix.
 
@@ -54,21 +54,26 @@ local Config = {
     -- This metadata is parsed from the EPUB's metadata, or from the filename
     meta_field = "Notes",
 
-    -- The field name where pronunciation audio will be sent to (leave blank to disable audio lookup).
+    -- The field name where word pronunciation audio will be sent to.
     audio_field = "VocabAudio",
 
-    -- Which audio driver to use when audio_field is set.
-    -- Built-in: "forvo", "voicevox". Use "none" to skip audio even if audio_field is set.
-    -- See audio_drivers/README.md for adding custom drivers.
-    audio_driver = "forvo",
+    -- The field name where sentence pronunciation audio will be sent to.
+    sentence_audio_field = "SentAudio",
 
-    -- Per-driver settings, keyed by driver id. Example:
-    -- audio_driver_settings = {
+    -- Word / sentence audio drivers (configured under General Settings → Audio in the menu).
+    -- Built-in: "forvo", "voicevox". Use "none" to skip.
+    -- See audio_drivers/README.md for adding custom drivers.
+    word_audio_driver = "forvo",
+    sentence_audio_driver = "none",
+
+    -- Per-driver settings for word audio, keyed by driver id. Example:
+    -- word_audio_driver_settings = {
     --     voicevox = {
     --         url = "http://192.168.0.1.lan:50121",
     --         speaker_id = "10000",
-    --         -- Optional: synthesize from a kana reading field + pitch accent position instead of the kanji
-    --         word_field = "KanaReading",
+    --         -- Optional: synthesize from a kana reading field + pitch accent position
+    --         -- instead of the default text (looked-up word).
+    --         text_field = "KanaReading",
     --         pitch_field = "VocabPitchNum",
     --         -- Optional AudioQuery params (defaults shown)
     --         -- speedScale = "1.0",
@@ -79,7 +84,17 @@ local Config = {
     --         -- postPhonemeLength = "0.1",
     --     },
     -- },
-    audio_driver_settings = {},
+    word_audio_driver_settings = {},
+
+    -- Per-driver settings for sentence audio (same shape as word_audio_driver_settings).
+    -- Default synthesis text is the context sentence when text_field is left blank.
+    -- sentence_audio_driver_settings = {
+    --     voicevox = {
+    --         url = "http://192.168.0.1.lan:50121",
+    --         speaker_id = "10000",
+    --     },
+    -- },
+    sentence_audio_driver_settings = {},
 
     -- list of extensions which should be enabled, by default they are all off
     -- an extension is turned on by listing its filename in the table below

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -67,6 +67,9 @@ local Config = {
     --     voicevox = {
     --         url = "http://192.168.0.1.lan:50121",
     --         speaker_id = "10000",
+    --         -- Optional: synthesize from a kana reading field + pitch accent position instead of the kanji
+    --         word_field = "KanaReading",
+    --         pitch_field = "VocabPitchNum",
     --     },
     -- },
     audio_driver_settings = {},

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -71,9 +71,9 @@ local Config = {
     --     voicevox = {
     --         url = "http://192.168.0.1.lan:50121",
     --         speaker_id = "10000",
-    --         -- Optional: synthesize from a kana reading field + pitch accent position
-    --         -- instead of the default text (looked-up word).
-    --         text_field = "KanaReading",
+    --         -- Optional: when BOTH are available, synthesize with pitch accent.
+    --         -- If either is missing, the original word is used.
+    --         kana_field = "KanaReading",
     --         pitch_field = "VocabPitchNum",
     --         -- Optional AudioQuery params (defaults shown)
     --         -- speedScale = "1.0",
@@ -87,13 +87,6 @@ local Config = {
     word_audio_driver_settings = {},
 
     -- Per-driver settings for sentence audio (same shape as word_audio_driver_settings).
-    -- Default synthesis text is the context sentence when text_field is left blank.
-    -- sentence_audio_driver_settings = {
-    --     voicevox = {
-    --         url = "http://192.168.0.1.lan:50121",
-    --         speaker_id = "10000",
-    --     },
-    -- },
     sentence_audio_driver_settings = {},
 
     -- list of extensions which should be enabled, by default they are all off

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -55,7 +55,9 @@ local Config = {
     meta_field = "Notes",
 
     -- The field name where word pronunciation audio will be sent to.
-    audio_field = "VocabAudio",
+    -- Legacy profiles may still use audio_field; that is used if word_audio_field is unset.
+    word_audio_field = "VocabAudio",
+    -- audio_field = "VocabAudio",
 
     -- The field name where sentence pronunciation audio will be sent to.
     sentence_audio_field = "SentAudio",


### PR DESCRIPTION
Hi, thanks for this plugin, it's great and I started using it recently for reading in Japanese.

This change wasn't requested but I wanted to add better support for audio so I thought I'd share what I came up with.

The current code only supports Forvo for audio retrieval, which can be unreliable (#93). It also only supports getting audio for the word, not for the context sentence.

This PR refactors audio to a driver based system. This means that in addition to Forvo (the default), people can contribute their own audio drivers to retrieve or generate audio from various sources. Audio can be retrieved for both the word and the context sentence.

Drivers are stored in the `audio_drivers` folder.

I have included a driver for generating audio using VoiceVox (can be self-hosted for generating free AI Japanese audio).

Each audio driver can specify its own driver settings (in VoiceVox's case things like server URL & speaker/voice ID).

Driver can be configured for the word & context sentence independently (e.g. retrieve the word from Forvo, the sentence from VoiceVox).

The audio driver is passed the full note data so any fields like KanaReading or PitchNum that might be helpful for generating the audio can be used (the VoiceVox driver makes use of this).

Drivers are expected to return a filename and either a URL to an audio file (like for Forvo) or a base64 string of the audio data.

The PR also includes these minor changes:
- Increased timeout when creating a note in AnkiConnect (prevents unnecessary timeout errors displaying)
- Update the "Add to Anki" button text to "Adding..." and "Added to Anki" to show visual confirmation to the user
- Renamed `audio_field` to `word_audio_field` (but maintains backward compatibility with `audio_field` if not present)

I think there should be no breaking changes. It defaults to the same behaviour: Forvo for word audio and nothing for sentence audio.

If you'd like me to make any changes, please let me know. Thank you.