### PR TITLE
fix: use KOReader's standard timeouts for AnkiConnect requests

### DIFF
--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -45,8 +45,8 @@ function AnkiConnect.sanitize_url(url)
     return valid_url, ssl ~= nil
 end
 
-function AnkiConnect.with_timeout(timeout, func)
-    socketutil:set_timeout(timeout)
+function AnkiConnect.with_timeout(block_timeout, total_timeout, func)
+    socketutil:set_timeout(block_timeout, total_timeout)
     local res = { func() } -- store all values returned by function
     socketutil:reset_timeout()
     return unpack(res)
@@ -101,7 +101,8 @@ function AnkiConnect:POST(opts)
         source = ltn12.source.string(payload)
     }
     logger.dbg("AnkiConnect#POST request:", req)
-    local status_code, response_headers, status = self.with_timeout(1, function() return socket.skip(1, http.request(req)) end)
+    local status_code, response_headers, status = self.with_timeout(socketutil.LARGE_BLOCK_TIMEOUT, socketutil.LARGE_TOTAL_TIMEOUT,
+        function() return socket.skip(1, http.request(req)) end)
     logger.dbg("AnkiConnect#POST response:", status_code, response_headers, status)
 
     if type(status_code) == "string" then return nil, status_code end


### PR DESCRIPTION
## Problem

`AnkiConnect:POST` wraps the request in a hard-coded **1 second** block timeout:

```lua
local status_code, response_headers, status = self.with_timeout(1, function() return socket.skip(1, http.request(req)) end)
```

On e-ink devices one second is frequently not enough. The Wi-Fi radio often has to wake from sleep, the CPUs are slow, and the request can involve media handling on the Anki side.

The failure mode is confusing rather than fatal: **the note is created successfully, but the response does not arrive in time**, so the plugin reports an error for an operation that actually succeeded. Users retry, and only later discover the note was there all along.

Reproduced consistently on a Kindle Paperwhite 4 (5.18.1) talking to Anki 26.08.1 over 2.4 GHz Wi-Fi: every "Add to Anki" reported a timeout, and every note showed up complete in the deck — sentence context, translation, Forvo audio and metadata included.

## Fix

Use `socketutil.LARGE_BLOCK_TIMEOUT` / `LARGE_TOTAL_TIMEOUT` instead of the magic number.

This is not an arbitrary value: it is exactly what `forvo.lua` in this same plugin already does, so networking behaviour becomes consistent across the codebase rather than differing between the two places that make HTTP requests.

`with_timeout()` now takes both a block and a total timeout, mirroring the signature of `socketutil:set_timeout(block_timeout, total_timeout)`. Previously only the block timeout was passed, leaving the total timeout at socketutil's fallback. There is a single call site, so the signature change is contained.

## Notes

- No behavioural change other than the timeouts
- Verified the file still parses with `luac -p`
- Happy to make the timeout user-configurable via the profile instead, if you would prefer that over the shared constants